### PR TITLE
UPSTREAM: wifi: ath12k: Address issues during beacon stats retrieval

### DIFF
--- a/drivers/net/wireless/ath/ath12k/core.c
+++ b/drivers/net/wireless/ath/ath12k/core.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 /*
  * Copyright (c) 2018-2021 The Linux Foundation. All rights reserved.
- * Copyright (c) 2021-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
@@ -1250,7 +1249,6 @@ void ath12k_fw_stats_reset(struct ath12k *ar)
 	spin_lock_bh(&ar->data_lock);
 	ath12k_fw_stats_free(&ar->fw_stats);
 	ar->fw_stats.num_vdev_recvd = 0;
-	ar->fw_stats.num_bcn_recvd = 0;
 	spin_unlock_bh(&ar->data_lock);
 }
 

--- a/drivers/net/wireless/ath/ath12k/core.h
+++ b/drivers/net/wireless/ath/ath12k/core.h
@@ -644,7 +644,6 @@ struct ath12k_fw_stats {
 	struct list_head vdevs;
 	struct list_head bcn;
 	u32 num_vdev_recvd;
-	u32 num_bcn_recvd;
 };
 
 struct ath12k_dbg_htt_stats {

--- a/drivers/net/wireless/ath/ath12k/debugfs.c
+++ b/drivers/net/wireless/ath/ath12k/debugfs.c
@@ -1283,6 +1283,7 @@ static int ath12k_open_vdev_stats(struct inode *inode, struct file *file)
 
 	ath12k_wmi_fw_stats_dump(ar, &ar->fw_stats, param.stats_id,
 				 buf);
+	ath12k_fw_stats_reset(ar);
 
 	file->private_data = no_free_ptr(buf);
 
@@ -1349,12 +1350,7 @@ static int ath12k_open_bcn_stats(struct inode *inode, struct file *file)
 
 	ath12k_wmi_fw_stats_dump(ar, &ar->fw_stats, param.stats_id,
 				 buf);
-	/* since beacon stats request is looped for all active VDEVs, saved fw
-	 * stats is not freed for each request until done for all active VDEVs
-	 */
-	spin_lock_bh(&ar->data_lock);
-	ath12k_fw_stats_bcn_free(&ar->fw_stats.bcn);
-	spin_unlock_bh(&ar->data_lock);
+	ath12k_fw_stats_reset(ar);
 
 	file->private_data = no_free_ptr(buf);
 
@@ -1415,6 +1411,7 @@ static int ath12k_open_pdev_stats(struct inode *inode, struct file *file)
 
 	ath12k_wmi_fw_stats_dump(ar, &ar->fw_stats, param.stats_id,
 				 buf);
+	ath12k_fw_stats_reset(ar);
 
 	file->private_data = no_free_ptr(buf);
 

--- a/drivers/net/wireless/ath/ath12k/mac.c
+++ b/drivers/net/wireless/ath/ath12k/mac.c
@@ -4837,8 +4837,6 @@ int ath12k_mac_get_fw_stats(struct ath12k *ar,
 	if (ah->state != ATH12K_HW_STATE_ON)
 		return -ENETDOWN;
 
-	ath12k_fw_stats_reset(ar);
-
 	reinit_completion(&ar->fw_stats_complete);
 	reinit_completion(&ar->fw_stats_done);
 
@@ -4936,6 +4934,7 @@ static int ath12k_mac_op_get_txpower(struct ieee80211_hw *hw,
 	ar->chan_tx_pwr = pdev->chan_tx_power / 2;
 	spin_unlock_bh(&ar->data_lock);
 	ar->last_tx_power_update = jiffies;
+	ath12k_fw_stats_reset(ar);
 
 send_tx_power:
 	*dbm = ar->chan_tx_pwr;
@@ -12701,14 +12700,18 @@ static void ath12k_mac_op_sta_statistics(struct ieee80211_hw *hw,
 
 	if (!signal &&
 	    ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
-	    !(ath12k_mac_get_fw_stats(ar, &params)))
+	    !(ath12k_mac_get_fw_stats(ar, &params))) {
 		signal = arsta->rssi_beacon;
+		ath12k_fw_stats_reset(ar);
+	}
 
 	params.stats_id = WMI_REQUEST_RSSI_PER_CHAIN_STAT;
 	if (!(sinfo->filled & BIT_ULL(NL80211_STA_INFO_CHAIN_SIGNAL)) &&
 	    ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
-	    !(ath12k_mac_get_fw_stats(ar, &params)))
+	    !(ath12k_mac_get_fw_stats(ar, &params))) {
 		ath12k_mac_put_chain_rssi(sinfo, arsta);
+		ath12k_fw_stats_reset(ar);
+	}
 
 	spin_lock_bh(&ar->data_lock);
 	noise_floor = ath12k_pdev_get_noise_floor(ar);
@@ -12792,8 +12795,10 @@ static void ath12k_mac_op_link_sta_statistics(struct ieee80211_hw *hw,
 
 	if (!signal &&
 	    ahsta->ahvif->vdev_type == WMI_VDEV_TYPE_STA &&
-	    !(ath12k_mac_get_fw_stats(ar, &params)))
+	    !(ath12k_mac_get_fw_stats(ar, &params))) {
 		signal = arsta->rssi_beacon;
+		ath12k_fw_stats_reset(ar);
+	}
 
 	if (signal) {
 		link_sinfo->signal =

--- a/drivers/net/wireless/ath/ath12k/wmi.c
+++ b/drivers/net/wireless/ath/ath12k/wmi.c
@@ -8413,18 +8413,10 @@ static void ath12k_wmi_fw_stats_process(struct ath12k *ar,
 			ath12k_warn(ab, "empty beacon stats");
 			return;
 		}
-		/* Mark end until we reached the count of all started VDEVs
-		 * within the PDEV
-		 */
-		if (ar->num_started_vdevs)
-			is_end = ((++ar->fw_stats.num_bcn_recvd) ==
-				  ar->num_started_vdevs);
 
 		list_splice_tail_init(&stats->bcn,
 				      &ar->fw_stats.bcn);
-
-		if (is_end)
-			complete(&ar->fw_stats_done);
+		complete(&ar->fw_stats_done);
 	}
 }
 

--- a/drivers/net/wireless/ath/ath12k/wmi.c
+++ b/drivers/net/wireless/ath/ath12k/wmi.c
@@ -8017,8 +8017,6 @@ void ath12k_wmi_fw_stats_dump(struct ath12k *ar,
 		buf[len - 1] = 0;
 	else
 		buf[len] = 0;
-
-	ath12k_fw_stats_reset(ar);
 }
 
 static void


### PR DESCRIPTION
Currently, retrieving beacon stats is getting failed with timed out error
when multiple BSSes are enabled. This patch series tries to address the
mentioned issue by the following,

#1: Reset the firmware stats only after retrieving the complete stats
 #2: Remove the wait timeout to get stats for all enabled BSSes during
 beacon stats retrieval.

---
Manish Dharanenthiran (2):
      wifi: ath12k: Make firmware stats reset caller-driven
      wifi: ath12k: Fix timeout error during beacon stats retrieval

 drivers/net/wireless/ath/ath12k/core.c    |  2 --
 drivers/net/wireless/ath/ath12k/core.h    |  1 -
 drivers/net/wireless/ath/ath12k/debugfs.c |  9 +++------
 drivers/net/wireless/ath/ath12k/mac.c     | 15 ++++++++++-----
 drivers/net/wireless/ath/ath12k/wmi.c     | 12 +-----------
 5 files changed, 14 insertions(+), 25 deletions(-)
---

[https://lore.kernel.org/all/20251031-beacon_stats-v1-0-f52fce7b03ac@qti.qualcomm.com/](url)
CRs-Fixed: 4398576