### PR TITLE
QCLINUX: arm64: configs: Added new rt.config for RT kernel

### DIFF
--- a/arch/arm64/configs/rt.config
+++ b/arch/arm64/configs/rt.config
@@ -1,0 +1,3 @@
+# rt.config for Real time kernel features
+CONFIG_EXPERT=y
+CONFIG_PREEMPT_RT=y


### PR DESCRIPTION
Enabled PREEMPT_RT in new rt.config to enable RT kernel features.

CRs-Fixed: 4402106