### PR TITLE
Workaround: PCI: Disable L1ss through quirk for HMT & Cologne

### DIFF
--- a/drivers/pci/quirks.c
+++ b/drivers/pci/quirks.c
@@ -2532,6 +2532,8 @@ static void quirk_disable_aspm_l1ss(struct pci_dev *dev)
 	pci_disable_link_state(dev, PCIE_LINK_STATE_L1_1 | PCIE_LINK_STATE_L1_2);
 }
 DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1103, quirk_disable_aspm_l1ss);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1107, quirk_disable_aspm_l1ss);
+DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_QCOM, 0x1112, quirk_disable_aspm_l1ss);
 
 /*
  * Some Pericom PCIe-to-PCI bridges in reverse mode need the PCIe Retrain


### PR DESCRIPTION
When PCIe L1ss is enabled, WLAN functionality is completely broken. There are some connectivity issues in this platform mostly with CLKREQ# pin.

Disable L1ss as workaround until actual issue get resolved.

CRs-Fixed: 4392425