### PR TITLE
QCLINUX: arm64: dts: qcom: Add camx overlay fixes for KLM

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-camera.dtsi
@@ -667,7 +667,7 @@
 		status = "ok";
 	};
 
-	qcom,cam-cpas {
+	cam_cpas: qcom,cam-cpas {
 		compatible = "qcom,cam-cpas";
 		label = "cpas";
 		arch-compat = "cpas_top";
@@ -743,8 +743,7 @@
 			       "ife5", "ife6", "ipe0", "sfe0", "sfe1",
 			       "cam-cdm-intf0", "rt-cdm0", "rt-cdm1", "rt-cdm2",
 			       "rt-cdm3", "icp0", "tpg17", "tpg18", "tpg19";
-
-		enable-secure-qos-update;
+		enable-secure-qos-update = <1>;
 		cell-index = <0>;
 		status = "ok";
 
@@ -816,7 +815,6 @@
 					                     CAM_CPAS_PATH_DATA_IFE_PIXEL_RAW>;
 					parent-node = <&level1_rt_wr0>;
 				};
-
 
 				ife_1_wr_1: ife-1-wr-1 {
 					cell-index = <4>;
@@ -958,8 +956,7 @@
 					node-name = "rt-cdm2-all-rd-2";
 					client-name = "rt-cdm2";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
-					traffic-transaction-type =
-					<CAM_CPAS_TRANSACTION_READ>;
+					traffic-transaction-type = <CAM_CPAS_TRANSACTION_READ>;
 					parent-node = <&level1_nrt_rd2>;
 				};
 
@@ -1086,8 +1083,7 @@
 				level3_nrt0_rd_wr_sum: level3-nrt0-rd-wr-sum {
 					cell-index = <30>;
 					node-name = "level3-nrt0-rd-wr-sum";
-					traffic-merge-type =
-					<CAM_CPAS_TRAFFIC_MERGE_SUM>;
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 
 					qcom,axi-port-mnoc {
 						cam-icc-path-names = "cam_sf_0";
@@ -1097,8 +1093,7 @@
 				level3_nrt1_rd_wr_sum: level3-nrt1-rd-wr-sum {
 					cell-index = <31>;
 					node-name = "level3-nrt1-rd-wr-sum";
-					traffic-merge-type =
-					<CAM_CPAS_TRAFFIC_MERGE_SUM>;
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 
 					qcom,axi-port-mnoc {
 						cam-icc-path-names = "cam_sf_icp";
@@ -1108,8 +1103,7 @@
 				level3_rt_rd_wr_sum: level3-rt-rd-wr-sum {
 					cell-index = <32>;
 					node-name = "level3-rt-rd-wr-sum";
-					traffic-merge-type =
-					<CAM_CPAS_TRAFFIC_MERGE_SUM>;
+					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 					ib-bw-voting-needed;
 
 					qcom,axi-port-mnoc {
@@ -1120,7 +1114,7 @@
 		};
 	};
 
-	qcom,cam-icp {
+	cam_icp_firmware: qcom,cam-icp {
 		compatible = "qcom,cam-icp";
 		compat-hw-name = "qcom,icp", "qcom,ipe0";
 		num-icp = <1>;
@@ -1148,8 +1142,8 @@
 		status = "ok";
 	};
 
-	qcom,cam-sync {
-		compatible = "qcom,cam-sync";
+	qcom,camera-main {
+		compatible = "qcom,camera";
 		status = "ok";
 	};
 
@@ -1274,8 +1268,8 @@
 		};
 	};
 
-	qcom,camera-main {
-		compatible = "qcom,camera";
+	qcom,cam-sync {
+		compatible = "qcom,cam-sync";
 		status = "ok";
 	};
 
@@ -1544,13 +1538,6 @@
 		interrupts = <GIC_SPI 604 IRQ_TYPE_EDGE_RISING>;
 		interrupt-names = "csid-lite4";
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		clock-names = "cam_cc_cpas_ife_lite_clk",
-			      "cam_cc_ife_lite_ahb_clk",
-			      "cam_cc_ife_lite_csid_clk_src",
-			      "cam_cc_ife_lite_csid_clk",
-			      "cam_cc_ife_lite_cphy_rx_clk",
-			      "cam_cc_ife_lite_clk_src",
-			      "cam_cc_ife_lite_clk";
 		clocks = <&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
 			 <&camcc CAM_CC_IFE_LITE_AHB_CLK>,
 			 <&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
@@ -1558,6 +1545,13 @@
 			 <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
 			 <&camcc CAM_CC_IFE_LITE_CLK_SRC>,
 			 <&camcc CAM_CC_IFE_LITE_CLK>;
+		clock-names = "cam_cc_cpas_ife_lite_clk",
+			      "cam_cc_ife_lite_ahb_clk",
+			      "cam_cc_ife_lite_csid_clk_src",
+			      "cam_cc_ife_lite_csid_clk",
+			      "cam_cc_ife_lite_cphy_rx_clk",
+			      "cam_cc_ife_lite_clk_src",
+			      "cam_cc_ife_lite_clk";
 		clock-rates = <0 0 400000000 0 0 400000000 0>,
 			      <0 0 400000000 0 0 480000000 0>;
 		clock-cntl-level = "svs_l1", "nominal";
@@ -1606,7 +1600,7 @@
 			      <400000000 0 600000000 0>;
 		clock-cntl-level = "svs_l1", "nominal";
 		nrt-device;
-		fw_name = "CAMERA_ICP";
+		fw_name = "qcom/sa8775p/CAMERA_ICP";
 		ubwc-ipe-fetch-cfg = <0x707b 0x7083>;
 		ubwc-ipe-write-cfg = <0x161ef 0x1620f>;
 		qos-val = <0xa0a>;
@@ -2000,7 +1994,6 @@
 				required-opps = <&rpmhpd_opp_nom>;
 			};
 		};
-
 	};
 
 	qcom,rt-cdm0 {
@@ -2140,12 +2133,12 @@
 		interrupts = <GIC_SPI 563 IRQ_TYPE_EDGE_RISING>;
 		interrupt-names = "sfe-lite0";
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		clock-names = "cam_cc_sfe_lite_0_fast_ahb_clk",
-			      "cam_cc_sfe_lite_0_clk",
-			      "cam_cc_cpas_sfe_lite_0_clk";
 		clocks = <&camcc CAM_CC_SFE_LITE_0_FAST_AHB_CLK>,
 			 <&camcc CAM_CC_SFE_LITE_0_CLK>,
 			 <&camcc CAM_CC_CPAS_SFE_LITE_0_CLK>;
+		clock-names = "cam_cc_sfe_lite_0_fast_ahb_clk",
+			      "cam_cc_sfe_lite_0_clk",
+			      "cam_cc_cpas_sfe_lite_0_clk";
 		clock-rates = <0 480000000 300000000>,
 			      <0 600000000 400000000>;
 		clock-cntl-level = "svs_l1", "nominal";

--- a/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-evk-camera-sensor.dtsi
@@ -205,6 +205,47 @@
 		status = "ok";
 	};
 
+	/*cam0-cmk_imx577*/
+	qcom,cam-sensor27 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <0>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_cam27>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active
+			     &cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend
+			     &cam_sensor_suspend_rst0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 72 0>,
+			<&tlmm 132 0>,
+			<&pmm8654au_0_gpios 7 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK0",
+				     "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <27>;
+		status = "ok";
+	};
+
 	eeprom_cam24: qcom,eeprom24 {
 		compatible = "qcom,eeprom";
 		cam_vio-supply = <&vreg_s4a>;
@@ -237,6 +278,41 @@
 		clock-cntl-level = "nominal";
 		clock-rates = <24000000>;
 		cell-index = <24>;
+		status = "ok";
+	};
+
+	eeprom_cam27: qcom,eeprom27 {
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk0_active
+			     &cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend
+			     &cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 72 0>,
+			<&tlmm 132 0>,
+			<&pmm8654au_0_gpios 7 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK0",
+				     "CAMIF_RESET0",
+				     "CAM_CUSTOM1";
+		sensor-mode = <0>;
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <27>;
 		status = "ok";
 	};
 };
@@ -401,6 +477,160 @@
 		cell-index = <21>;
 		status = "ok";
 	};
+
+	/*cam1-imx577*/
+	qcom,cam-sensor26 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_cam26>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk1_active
+			     &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+			     &cam_sensor_suspend_rst1>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 73 0>,
+			<&tlmm 133 0>,
+			<&pmm8654au_0_gpios 8 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK1",
+				     "CAMIF_RESET1",
+				     "CAM_CUSTOM1";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <26>;
+		status = "ok";
+	};
+
+	/*cam1-cmk_imx577*/
+	qcom,cam-sensor28 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_cam28>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk1_active
+			     &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+			     &cam_sensor_suspend_rst1>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 73 0>,
+			<&tlmm 133 0>,
+			<&pmm8654au_0_gpios 8 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK1",
+				     "CAMIF_RESET1",
+				     "CAM_CUSTOM1";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <28>;
+		status = "ok";
+	};
+
+	eeprom_cam26: qcom,eeprom26 {
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk1_active
+			     &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+			     &cam_sensor_suspend_rst1>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 73 0>,
+			<&tlmm 133 0>,
+			<&pmm8654au_0_gpios 8 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1",
+				     "CAM_RESET1",
+				     "CAM_CUSTOM1";
+		sensor-mode = <0>;
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <26>;
+		status = "ok";
+	};
+
+	eeprom_cam28: qcom,eeprom28 {
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk1_active
+			     &cam_sensor_active_rst1>;
+		pinctrl-1 = <&cam_sensor_mclk1_suspend
+			     &cam_sensor_suspend_rst1>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 73 0>,
+			<&tlmm 133 0>,
+			<&pmm8654au_0_gpios 8 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK1",
+				     "CAM_RESET1",
+				     "CAM_CUSTOM1";
+		sensor-mode = <0>;
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK1_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <28>;
+		status = "ok";
+	};
 };
 
 &cam_cci2 {
@@ -563,6 +793,83 @@
 		cell-index = <22>;
 		status = "ok";
 	};
+
+	/*cam2-cmk_imx577*/
+	qcom,cam-sensor29 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <2>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_cam29>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk2_active
+			     &cam_sensor_active_rst2>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend
+			     &cam_sensor_suspend_rst2>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 74 0>,
+			<&tlmm 134 0>,
+			<&pmm8654au_0_gpios 9 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK2",
+				     "CAMIF_RESET2",
+				     "CAM_CUSTOM1";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK2_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <29>;
+		status = "ok";
+	};
+
+	eeprom_cam29: qcom,eeprom29 {
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk2_active
+			     &cam_sensor_active_rst2>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend
+			     &cam_sensor_suspend_rst2>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpios = <&tlmm 74 0>,
+			<&tlmm 134 0>,
+			<&pmm8654au_0_gpios 9 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK2",
+				     "CAM_RESET2",
+				     "CAM_CUSTOM1";
+		sensor-mode = <0>;
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK2_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <29>;
+		status = "ok";
+	};
 };
 
 &cam_cci3 {
@@ -723,6 +1030,83 @@
 		clock-cntl-level = "nominal";
 		clock-rates = <24000000>;
 		cell-index = <23>;
+		status = "ok";
+	};
+
+	/*cam3-cmk_imx577*/
+	qcom,cam-sensor30 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <3>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		eeprom-src = <&eeprom_cam30>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk3_active
+			     &cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend
+			     &cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 75 0>,
+			<&tlmm 135 0>,
+			<&pmm8654au_0_gpios 10 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK3",
+				     "CAMIF_RESET3",
+				     "CAM_CUSTOM1";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <30>;
+		status = "ok";
+	};
+
+	eeprom_cam30: qcom,eeprom30 {
+		compatible = "qcom,eeprom";
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-0 = <&cam_sensor_mclk3_active
+			     &cam_sensor_active_rst3>;
+		pinctrl-1 = <&cam_sensor_mclk3_suspend
+			     &cam_sensor_suspend_rst3>;
+		gpios = <&tlmm 75 0>,
+			<&tlmm 135 0>,
+			<&pmm8654au_0_gpios 10 0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAMIF_MCLK3",
+				     "CAM_RESET3",
+				     "CAM_CUSTOM1";
+		sensor-mode = <0>;
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK3_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <30>;
 		status = "ok";
 	};
 };

--- a/arch/arm64/boot/dts/qcom/monaco-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-camera-sensor.dtsi
@@ -374,7 +374,7 @@
 &soc {
 	qcom,cam-res-mgr {
 		compatible = "qcom,cam-res-mgr";
-		gpios-shared = <518 519 520 521>;
+		gpios-shared = <609 610 611>;
 		status = "ok";
 	};
 };

--- a/arch/arm64/boot/dts/qcom/monaco-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco-camera.dtsi
@@ -528,7 +528,7 @@
 		status = "ok";
 	};
 
-	qcom,cam-cpas {
+	cam_cpas: qcom,cam-cpas {
 		compatible = "qcom,cam-cpas";
 		label = "cpas";
 		arch-compat = "cpas_top";
@@ -565,8 +565,8 @@
 			      "cam_cc_qdss_debug_xo_clk";
 		src-clock-name = "cam_cc_fast_ahb_clk_src";
 		clock-rates = <0 0 0 0 0 0 0 0 0 0 0>,
-			<0 0 0 80000000 0 0 300000000 0 400000000 0 0>,
-			<0 0 0 80000000 0 0 400000000 0 400000000 0 0>;
+			      <0 0 0 80000000 0 0 300000000 0 400000000 0 0>,
+			      <0 0 0 80000000 0 0 400000000 0 400000000 0 0>;
 		clock-cntl-level = "suspend", "svs_l1", "nominal";
 		clock-names-option = "cam_icp_clk";
 		clocks-option = <&camcc CAM_CC_ICP_CLK>;
@@ -605,7 +605,7 @@
 			       "ife5", "ife6", "ipe0", "sfe0", "sfe1",
 			       "cam-cdm-intf0", "rt-cdm0", "rt-cdm1", "rt-cdm2",
 			       "rt-cdm3", "icp0", "tpg13", "tpg14", "tpg15";
-		enable-secure-qos-update;
+		enable-secure-qos-update = <1>;
 		cell-index = <0>;
 		status = "ok";
 
@@ -679,7 +679,7 @@
 				};
 
 				ife_1_wr_1: ife-1-wr-1 {
-					cell-index = <3>;
+					cell-index = <4>;
 					node-name = "ife-1-wr-1";
 					client-name = "ife1";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_UBWC>;
@@ -693,7 +693,7 @@
 				};
 
 				ife_lite_0_wr_0: ife-lite-0-wr-0 {
-					cell-index = <4>;
+					cell-index = <5>;
 					node-name = "ife-lite-0-wr-0";
 					client-name = "ife2";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_RDI_PIXEL_RAW>;
@@ -707,7 +707,7 @@
 				};
 
 				ife_lite_1_wr_0: ife-lite-1-wr-0 {
-					cell-index = <5>;
+					cell-index = <6>;
 					node-name = "ife-lite-1-wr-0";
 					client-name = "ife3";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_RDI_PIXEL_RAW>;
@@ -721,7 +721,7 @@
 				};
 
 				ife_lite_2_wr_0: ife-lite-2-wr-0 {
-					cell-index = <6>;
+					cell-index = <7>;
 					node-name = "ife-lite-2-wr-0";
 					client-name = "ife4";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_RDI_PIXEL_RAW>;
@@ -735,7 +735,7 @@
 				};
 
 				ife_lite_3_wr_0: ife-lite-3-wr-0 {
-					cell-index = <7>;
+					cell-index = <8>;
 					node-name = "ife-lite-3-wr-0";
 					client-name = "ife5";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_RDI_PIXEL_RAW>;
@@ -749,7 +749,7 @@
 				};
 
 				ife_lite_4_wr_0: ife-lite-4-wr-0 {
-					cell-index = <8>;
+					cell-index = <9>;
 					node-name = "ife-lite-4-wr-0";
 					client-name = "ife6";
 					traffic-data = <CAM_CPAS_PATH_DATA_IFE_RDI_PIXEL_RAW>;
@@ -763,7 +763,7 @@
 				};
 
 				ipe_0_rd_all: ipe-0-rd-all {
-					cell-index = <9>;
+					cell-index = <10>;
 					node-name = "ipe-0-rd-all";
 					client-name = "ipe0";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -774,7 +774,7 @@
 				};
 
 				ipe_0_wr_2: ipe-0-wr-2 {
-					cell-index = <10>;
+					cell-index = <11>;
 					node-name = "ipe-0-wr-2";
 					client-name = "ipe0";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -787,7 +787,7 @@
 				};
 
 				ipe_cdm0_all_rd: ipe-cdm0-all-rd {
-					cell-index = <11>;
+					cell-index = <12>;
 					node-name = "ipe-cdm0-all-rd";
 					client-name = "ipe0";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -796,7 +796,7 @@
 				};
 
 				rt_cdm0_all_rd_2: rt-cdm0-all-rd-2 {
-					cell-index = <12>;
+					cell-index = <13>;
 					node-name = "rt-cdm0-all-rd-2";
 					client-name = "rt-cdm0";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -805,7 +805,7 @@
 				};
 
 				rt_cdm1_all_rd_2: rt-cdm1-all-rd-2 {
-					cell-index = <13>;
+					cell-index = <14>;
 					node-name = "rt-cdm1-all-rd-2";
 					client-name = "rt-cdm1";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -814,7 +814,7 @@
 				};
 
 				rt_cdm2_all_rd_2: rt-cdm2-all-rd-2 {
-					cell-index = <14>;
+					cell-index = <15>;
 					node-name = "rt-cdm2-all-rd-2";
 					client-name = "rt-cdm2";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -823,7 +823,7 @@
 				};
 
 				rt_cdm3_all_rd_2: rt-cdm3-all-rd-2 {
-					cell-index = <15>;
+					cell-index = <16>;
 					node-name = "rt-cdm3-all-rd-2";
 					client-name = "rt-cdm3";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -832,7 +832,7 @@
 				};
 
 				sfe_0_rd_0: sfe-0-rd-0 {
-					cell-index = <16>;
+					cell-index = <17>;
 					node-name = "sfe-0-rd-0";
 					client-name = "sfe0";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -842,7 +842,7 @@
 				};
 
 				sfe_1_rd_0: sfe-1-rd-0 {
-					cell-index = <17>;
+					cell-index = <18>;
 					node-name = "sfe-1-rd-0";
 					client-name = "sfe1";
 					traffic-data = <CAM_CPAS_PATH_DATA_ALL>;
@@ -857,28 +857,28 @@
 				camnoc-max-needed;
 
 				level1_nrt_rd2: level1-nrt-rd2 {
-					cell-index = <22>;
+					cell-index = <19>;
 					node-name = "level1-nrt-rd2";
 					parent-node = <&level2_nrt_rd2>;
 					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 				};
 
 				level1_rt_rd0: level1-rt-read0 {
-					cell-index = <21>;
+					cell-index = <20>;
 					node-name = "level1-rt-rd0";
 					parent-node = <&level2_rt_rd0>;
 					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 				};
 
 				level1_rt_wr0: level1-rt-wr0 {
-					cell-index = <19>;
+					cell-index = <21>;
 					node-name = "level1-rt-wr0";
 					parent-node = <&level2_rt_wr0>;
 					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
 				};
 
 				level1_rt_wr1: level1-rt-wr1 {
-					cell-index = <20>;
+					cell-index = <22>;
 					node-name = "level1-rt-wr1";
 					parent-node = <&level2_rt_wr1>;
 					traffic-merge-type = <CAM_CPAS_TRAFFIC_MERGE_SUM>;
@@ -976,10 +976,9 @@
 		};
 	};
 
-	qcom,cam-icp {
+	cam_icp_firmware: qcom,cam-icp {
 		compatible = "qcom,cam-icp";
-		compat-hw-name = "qcom,icp",
-			"qcom,ipe0";
+		compat-hw-name = "qcom,icp", "qcom,ipe0";
 		num-icp = <1>;
 		num-ipe = <1>;
 		icp_use_pil;
@@ -1023,6 +1022,7 @@
 			cam-smmu-label = "rt-cdm";
 			dma-coherent;
 			multiple-client-devices;
+
 			rt_cdm_iova_mem_map: iova-mem-map {
 				iova-mem-region-io {
 					/* IO region is approximately 4.0 GB */
@@ -1059,6 +1059,7 @@
 					iova-region-id = <0x6>;
 					subregion_support;
 					status = "ok";
+
 					/* Used for HFI queues/sec heap */
 					iova-mem-region-generic-region {
 						iova-region-name = "icp_hfi";
@@ -1096,7 +1097,6 @@
 					iova-region-id = <0x1>;
 					status = "ok";
 				};
-
 			};
 		};
 
@@ -1298,90 +1298,36 @@
 		};
 	};
 
-	cam_csid_lite3: qcom,csid-lite3 {
-		cell-index = <5>;
-		compatible = "qcom,csid-lite692";
-		reg-names = "csid-lite3";
-		reg = <0x0 0xac90000 0x0 0xf01>;
-		reg-cam-base = <0x90000>;
-		rt-wrapper-base = <0x83000>;
-		interrupt-names = "csid-lite3";
-		interrupts = <GIC_SPI 758 IRQ_TYPE_EDGE_RISING>;
-		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		clock-names =
-			"cam_cc_cpas_ife_lite_clk",
-			"cam_cc_ife_lite_ahb_clk",
-			"cam_cc_ife_lite_csid_clk_src",
-			"cam_cc_ife_lite_csid_clk",
-			"cam_cc_ife_lite_cphy_rx_clk",
-			"cam_cc_ife_lite_clk_src",
-			"cam_cc_ife_lite_clk";
-		clocks =
-			<&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
-			<&camcc CAM_CC_IFE_LITE_AHB_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CLK>;
-		clock-rates =
-			<0 0 400000000 0 0 400000000 0>,
-			<0 0 400000000 0 0 480000000 0>;
-		clock-cntl-level = "svs_l1", "nominal";
-		src-clock-name = "cam_cc_ife_lite_csid_clk_src";
-		operating-points-v2 = <&csid_lite3_opp_table>;
-
-		clock-control-debugfs = "true";
-		status = "ok";
-
-		csid_lite3_opp_table: opp-table {
-			compatible = "operating-points-v2";
-
-			opp-400000000 {
-				opp-hz = /bits/ 64 <400000000>;
-				required-opps = <&rpmhpd_opp_svs_l1>;
-			};
-			opp-480000000 {
-				opp-hz = /bits/ 64 <480000000>;
-				required-opps = <&rpmhpd_opp_nom>;
-			};
-		};
-	};
-
 	cam_csid_lite2: qcom,csid-lite2 {
-		cell-index = <4>;
 		compatible = "qcom,csid-lite692";
-		reg-names = "csid-lite2";
 		reg = <0x0 0xac8c000 0x0 0xf01>;
+		reg-names = "csid-lite2";
 		reg-cam-base = <0x8c000>;
 		rt-wrapper-base = <0x83000>;
-		interrupt-names = "csid-lite2";
 		interrupts = <GIC_SPI 759 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "csid-lite2";
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		clock-names =
-			"cam_cc_cpas_ife_lite_clk",
-			"cam_cc_ife_lite_ahb_clk",
-			"cam_cc_ife_lite_csid_clk_src",
-			"cam_cc_ife_lite_csid_clk",
-			"cam_cc_ife_lite_cphy_rx_clk",
-			"cam_cc_ife_lite_clk_src",
-			"cam_cc_ife_lite_clk";
-		clocks =
-			<&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
-			<&camcc CAM_CC_IFE_LITE_AHB_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CLK>;
-		clock-rates =
-			<0 0 400000000 0 0 400000000 0>,
-			<0 0 400000000 0 0 480000000 0>;
+		clocks = <&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_AHB_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CLK>;
+		clock-names = "cam_cc_cpas_ife_lite_clk",
+			      "cam_cc_ife_lite_ahb_clk",
+			      "cam_cc_ife_lite_csid_clk_src",
+			      "cam_cc_ife_lite_csid_clk",
+			      "cam_cc_ife_lite_cphy_rx_clk",
+			      "cam_cc_ife_lite_clk_src",
+			      "cam_cc_ife_lite_clk";
+		clock-rates = <0 0 400000000 0 0 400000000 0>,
+			      <0 0 400000000 0 0 480000000 0>;
 		clock-cntl-level = "svs_l1", "nominal";
 		src-clock-name = "cam_cc_ife_lite_csid_clk_src";
 		operating-points-v2 = <&csid_lite2_opp_table>;
-
 		clock-control-debugfs = "true";
+		cell-index = <4>;
 		status = "ok";
 
 		csid_lite2_opp_table: opp-table {
@@ -1391,6 +1337,54 @@
 				opp-hz = /bits/ 64 <400000000>;
 				required-opps = <&rpmhpd_opp_svs_l1>;
 			};
+
+			opp-480000000 {
+				opp-hz = /bits/ 64 <480000000>;
+				required-opps = <&rpmhpd_opp_nom>;
+			};
+		};
+	};
+
+	cam_csid_lite3: qcom,csid-lite3 {
+		compatible = "qcom,csid-lite692";
+		reg = <0x0 0xac90000 0x0 0xf01>;
+		reg-names = "csid-lite3";
+		reg-cam-base = <0x90000>;
+		rt-wrapper-base = <0x83000>;
+		interrupts = <GIC_SPI 758 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "csid-lite3";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		clocks = <&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_AHB_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CLK>;
+		clock-names = "cam_cc_cpas_ife_lite_clk",
+			      "cam_cc_ife_lite_ahb_clk",
+			      "cam_cc_ife_lite_csid_clk_src",
+			      "cam_cc_ife_lite_csid_clk",
+			      "cam_cc_ife_lite_cphy_rx_clk",
+			      "cam_cc_ife_lite_clk_src",
+			      "cam_cc_ife_lite_clk";
+		clock-rates = <0 0 400000000 0 0 400000000 0>,
+			      <0 0 400000000 0 0 480000000 0>;
+		clock-cntl-level = "svs_l1", "nominal";
+		src-clock-name = "cam_cc_ife_lite_csid_clk_src";
+		operating-points-v2 = <&csid_lite3_opp_table>;
+		clock-control-debugfs = "true";
+		cell-index = <5>;
+		status = "ok";
+
+		csid_lite3_opp_table: opp-table {
+			compatible = "operating-points-v2";
+
+			opp-400000000 {
+				opp-hz = /bits/ 64 <400000000>;
+				required-opps = <&rpmhpd_opp_svs_l1>;
+			};
+
 			opp-480000000 {
 				opp-hz = /bits/ 64 <480000000>;
 				required-opps = <&rpmhpd_opp_nom>;
@@ -1399,39 +1393,35 @@
 	};
 
 	cam_csid_lite4: qcom,csid-lite4 {
-		cell-index = <6>;
 		compatible = "qcom,csid-lite692";
-		reg-names = "csid-lite4";
 		reg = <0x0 0xac94000 0x0 0xf01>;
+		reg-names = "csid-lite4";
 		reg-cam-base = <0x94000>;
 		rt-wrapper-base = <0x83000>;
-		interrupt-names = "csid-lite4";
 		interrupts = <GIC_SPI 604 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "csid-lite4";
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
-		clock-names =
-			"cam_cc_cpas_ife_lite_clk",
-			"cam_cc_ife_lite_ahb_clk",
-			"cam_cc_ife_lite_csid_clk_src",
-			"cam_cc_ife_lite_csid_clk",
-			"cam_cc_ife_lite_cphy_rx_clk",
-			"cam_cc_ife_lite_clk_src",
-			"cam_cc_ife_lite_clk";
-		clocks =
-			<&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
-			<&camcc CAM_CC_IFE_LITE_AHB_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CSID_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
-			<&camcc CAM_CC_IFE_LITE_CLK_SRC>,
-			<&camcc CAM_CC_IFE_LITE_CLK>;
-		clock-rates =
-			<0 0 400000000 0 0 400000000 0>,
-			<0 0 400000000 0 0 480000000 0>;
+		clocks = <&camcc CAM_CC_CPAS_IFE_LITE_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_AHB_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CSID_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CPHY_RX_CLK>,
+			 <&camcc CAM_CC_IFE_LITE_CLK_SRC>,
+			 <&camcc CAM_CC_IFE_LITE_CLK>;
+		clock-names = "cam_cc_cpas_ife_lite_clk",
+			      "cam_cc_ife_lite_ahb_clk",
+			      "cam_cc_ife_lite_csid_clk_src",
+			      "cam_cc_ife_lite_csid_clk",
+			      "cam_cc_ife_lite_cphy_rx_clk",
+			      "cam_cc_ife_lite_clk_src",
+			      "cam_cc_ife_lite_clk";
+		clock-rates = <0 0 400000000 0 0 400000000 0>,
+			      <0 0 400000000 0 0 480000000 0>;
 		clock-cntl-level = "svs_l1", "nominal";
 		src-clock-name = "cam_cc_ife_lite_csid_clk_src";
 		operating-points-v2 = <&csid_lite4_opp_table>;
-
 		clock-control-debugfs = "true";
+		cell-index = <6>;
 		status = "ok";
 
 		csid_lite4_opp_table: opp-table {
@@ -1441,6 +1431,7 @@
 				opp-hz = /bits/ 64 <400000000>;
 				required-opps = <&rpmhpd_opp_svs_l1>;
 			};
+
 			opp-480000000 {
 				opp-hz = /bits/ 64 <480000000>;
 				required-opps = <&rpmhpd_opp_nom>;
@@ -1472,7 +1463,7 @@
 			      <400000000 0 600000000 0>;
 		clock-cntl-level = "svs_l1", "nominal";
 		nrt-device;
-		fw_name = "CAMERA_ICP";
+		fw_name = "qcom/qcs8300/CAMERA_ICP";
 		ubwc-ipe-fetch-cfg = <0x707b 0x7083>;
 		ubwc-ipe-write-cfg = <0x161ef 0x1620f>;
 		qos-val = <0xa0a>;
@@ -1489,6 +1480,7 @@
 				opp-hz = /bits/ 64 <480000000>;
 				required-opps = <&rpmhpd_opp_svs_l1>;
 			};
+
 			opp-600000000 {
 				opp-hz = /bits/ 64 <600000000>;
 				required-opps = <&rpmhpd_opp_nom>;
@@ -1532,6 +1524,7 @@
 				opp-hz = /bits/ 64 <480000000>;
 				required-opps = <&rpmhpd_opp_svs_l1>;
 			};
+
 			opp-600000000 {
 				opp-hz = /bits/ 64 <600000000>;
 				required-opps = <&rpmhpd_opp_nom>;
@@ -1575,6 +1568,7 @@
 				opp-hz = /bits/ 64 <480000000>;
 				required-opps = <&rpmhpd_opp_svs_l1>;
 			};
+
 			opp-600000000 {
 				opp-hz = /bits/ 64 <600000000>;
 				required-opps = <&rpmhpd_opp_nom>;

--- a/arch/arm64/boot/dts/qcom/qcs6490-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/qcs6490-camera.dtsi
@@ -32,7 +32,7 @@
 		clock-cntl-level = "lowsvs", "svs", "svs_l1", "nominal";
 		src-clock-name = "soc_fast_ahb";
 		operating-points-v2 = <&a5_opp_table>;
-		fw_name = "CAMERA_ICP_170.elf";
+		fw_name = "qcom/qcm6490/CAMERA_ICP_170.elf";
 		ubwc-ipe-fetch-cfg = <0x7073 0x707b>;
 		ubwc-ipe-write-cfg = <0x161cf 0x161ef>;
 		ubwc-bps-fetch-cfg = <0x7073 0x707b>;
@@ -620,8 +620,8 @@
 	qcom,cam-icp {
 		compatible = "qcom,cam-icp";
 		compat-hw-name = "qcom,a5",
-			"qcom,ipe0",
-			"qcom,bps";
+				 "qcom,ipe0",
+				 "qcom,bps";
 		num-a5 = <1>;
 		num-ipe = <1>;
 		num-bps = <1>;
@@ -643,7 +643,7 @@
 	qcom,cam-jpeg {
 		compatible = "qcom,cam-jpeg";
 		compat-hw-name = "qcom,jpegenc",
-			"qcom,jpegdma";
+				 "qcom,jpegdma";
 		num-jpeg-enc = <1>;
 		num-jpeg-dma = <1>;
 		status = "ok";


### PR DESCRIPTION
The following changes are backported from the 6.19 kernel into the 6.18.y stable branch.

- Fix the indentation issue.
- Update DT clock property name after clock.
- Short DT nodes.
- Fix indexing issue.
- Update gpios shared pin.
- Change the path for the camera firmware.
- Enable imx577 sensor on lemans boards from slot0 to slot3.

CRs-Fixed: 4425301