### PR TITLE
change pil camera memory map on qli 2.0

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos.dtsi
+++ b/arch/arm64/boot/dts/qcom/talos.dtsi
@@ -654,6 +654,11 @@
 			reg = <0x0 0x97715000 0x0 0x2000>;
 			no-map;
 		};
+
+		pil_camera_mem: pil-camera-region@97717000 {
+			reg = <0x0 0x97717000 0x0 0x800000>;
+			no-map;
+		};
 	};
 
 	soc: soc@0 {


### PR DESCRIPTION
Add the pil camera carveout region based on v2 memory map.

CRs-Fixed: 4426649