### PR TITLE
FROMLIST: drm/bridge: lt9611uxc: reset edid_read on disconnect

### DIFF
--- a/drivers/gpu/drm/bridge/lontium-lt9611uxc.c
+++ b/drivers/gpu/drm/bridge/lontium-lt9611uxc.c
@@ -174,6 +174,9 @@ static void lt9611uxc_hpd_work(struct work_struct *work)
 	connected = lt9611uxc->hdmi_connected;
 	mutex_unlock(&lt9611uxc->ocm_lock);
 
+	if (!connected)
+		lt9611uxc->edid_read = false;
+
 	drm_bridge_hpd_notify(&lt9611uxc->bridge,
 			      connected ?
 			      connector_status_connected :


### PR DESCRIPTION
Currently edid_read has value from previous connect session and resulting in drm using older edid before new edid is available in lt9611uxc.
Reset edid_read so that correct status is updated and correct edid is available for drm.

Link: https://lore.kernel.org/lkml/20260202-lt9611uxc-reset-edid-v2-1-b1e1d72edc90@oss.qualcomm.com/
CRs-Fixed: 4144967