### PR TITLE
Backport pcie device tree changes

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -262,6 +262,30 @@
 		regulator-max-microvolt = <3700000>;
 	};
 
+	vdd_ntn_0p9: regulator-vdd-ntn-0p9 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDD_NTN_0P9";
+		gpio = <&pm8350c_gpios 2 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <899400>;
+		regulator-max-microvolt = <899400>;
+		enable-active-high;
+		pinctrl-0 = <&ntn_0p9_en>;
+		pinctrl-names = "default";
+		regulator-enable-ramp-delay = <4300>;
+	};
+
+	vdd_ntn_1p8: regulator-vdd-ntn-1p8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDD_NTN_1P8";
+		gpio = <&pm8350c_gpios 3 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+		pinctrl-0 = <&ntn_1p8_en>;
+		pinctrl-names = "default";
+		regulator-enable-ramp-delay = <10000>;
+	};
+
 	wcn6750-pmu {
 		compatible = "qcom,wcn6750-pmu";
 		pinctrl-0 = <&bt_en>;
@@ -841,6 +865,78 @@
 	vdda-pll-supply = <&vreg_l6b_1p2>;
 
 	status = "okay";
+};
+
+&pcie1_port0 {
+	pcie@0,0 {
+		compatible = "pci1179,0623";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		device_type = "pci";
+		ranges;
+		bus-range = <0x2 0xff>;
+
+		vddc-supply = <&vdd_ntn_0p9>;
+		vdd18-supply = <&vdd_ntn_1p8>;
+		vdd09-supply = <&vdd_ntn_0p9>;
+		vddio1-supply = <&vdd_ntn_1p8>;
+		vddio2-supply = <&vdd_ntn_1p8>;
+		vddio18-supply = <&vdd_ntn_1p8>;
+
+		i2c-parent = <&i2c0 0x77>;
+
+		resx-gpios = <&pm8350c_gpios 1 GPIO_ACTIVE_LOW>;
+
+		pinctrl-0 = <&tc9563_resx_n>;
+		pinctrl-names = "default";
+
+		pcie@1,0 {
+			reg = <0x20800 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			device_type = "pci";
+			ranges;
+			bus-range = <0x3 0xff>;
+		};
+
+		pcie@2,0 {
+			reg = <0x21000 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+
+			device_type = "pci";
+			ranges;
+			bus-range = <0x4 0xff>;
+		};
+
+		pcie@3,0 {
+			reg = <0x21800 0x0 0x0 0x0 0x0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			device_type = "pci";
+			ranges;
+			bus-range = <0x5 0xff>;
+
+			pci@0,0 {
+				reg = <0x50000 0x0 0x0 0x0 0x0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				device_type = "pci";
+				ranges;
+			};
+
+			pci@0,1 {
+				reg = <0x50100 0x0 0x0 0x0 0x0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				device_type = "pci";
+				ranges;
+			};
+		};
+	};
 };
 
 &pm7325_gpios {
@@ -1459,6 +1555,38 @@
 				temperature = <115000>;
 			};
 		};
+	};
+};
+
+&pm8350c_gpios {
+	ntn_0p9_en: ntn-0p9-en-state {
+		pins = "gpio2";
+		function = "normal";
+
+		bias-disable;
+		input-disable;
+		output-enable;
+		power-source = <0>;
+	};
+
+	ntn_1p8_en: ntn-1p8-en-state {
+		pins = "gpio3";
+		function = "normal";
+
+		bias-disable;
+		input-disable;
+		output-enable;
+		power-source = <0>;
+	};
+
+	tc9563_resx_n: tc9563-resx-state {
+		pins = "gpio1";
+		function = "normal";
+
+		bias-disable;
+		input-disable;
+		output-enable;
+		power-source = <0>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -262,30 +262,6 @@
 		regulator-max-microvolt = <3700000>;
 	};
 
-	vdd_ntn_0p9: regulator-vdd-ntn-0p9 {
-		compatible = "regulator-fixed";
-		regulator-name = "VDD_NTN_0P9";
-		gpio = <&pm8350c_gpios 2 GPIO_ACTIVE_HIGH>;
-		regulator-min-microvolt = <899400>;
-		regulator-max-microvolt = <899400>;
-		enable-active-high;
-		pinctrl-0 = <&ntn_0p9_en>;
-		pinctrl-names = "default";
-		regulator-enable-ramp-delay = <4300>;
-	};
-
-	vdd_ntn_1p8: regulator-vdd-ntn-1p8 {
-		compatible = "regulator-fixed";
-		regulator-name = "VDD_NTN_1P8";
-		gpio = <&pm8350c_gpios 3 GPIO_ACTIVE_HIGH>;
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		enable-active-high;
-		pinctrl-0 = <&ntn_1p8_en>;
-		pinctrl-names = "default";
-		regulator-enable-ramp-delay = <10000>;
-	};
-
 	wcn6750-pmu {
 		compatible = "qcom,wcn6750-pmu";
 		pinctrl-0 = <&bt_en>;
@@ -867,78 +843,6 @@
 	status = "okay";
 };
 
-&pcie1_port0 {
-	pcie@0,0 {
-		compatible = "pci1179,0623";
-		reg = <0x10000 0x0 0x0 0x0 0x0>;
-		#address-cells = <3>;
-		#size-cells = <2>;
-
-		device_type = "pci";
-		ranges;
-		bus-range = <0x2 0xff>;
-
-		vddc-supply = <&vdd_ntn_0p9>;
-		vdd18-supply = <&vdd_ntn_1p8>;
-		vdd09-supply = <&vdd_ntn_0p9>;
-		vddio1-supply = <&vdd_ntn_1p8>;
-		vddio2-supply = <&vdd_ntn_1p8>;
-		vddio18-supply = <&vdd_ntn_1p8>;
-
-		i2c-parent = <&i2c0 0x77>;
-
-		reset-gpios = <&pm8350c_gpios 1 GPIO_ACTIVE_LOW>;
-
-		pinctrl-0 = <&tc9563_rsex_n>;
-		pinctrl-names = "default";
-
-		pcie@1,0 {
-			reg = <0x20800 0x0 0x0 0x0 0x0>;
-			#address-cells = <3>;
-			#size-cells = <2>;
-
-			device_type = "pci";
-			ranges;
-			bus-range = <0x3 0xff>;
-		};
-
-		pcie@2,0 {
-			reg = <0x21000 0x0 0x0 0x0 0x0>;
-			#address-cells = <3>;
-			#size-cells = <2>;
-
-			device_type = "pci";
-			ranges;
-			bus-range = <0x4 0xff>;
-		};
-
-		pcie@3,0 {
-			reg = <0x21800 0x0 0x0 0x0 0x0>;
-			#address-cells = <3>;
-			#size-cells = <2>;
-			device_type = "pci";
-			ranges;
-			bus-range = <0x5 0xff>;
-
-			pci@0,0 {
-				reg = <0x50000 0x0 0x0 0x0 0x0>;
-				#address-cells = <3>;
-				#size-cells = <2>;
-				device_type = "pci";
-				ranges;
-			};
-
-			pci@0,1 {
-				reg = <0x50100 0x0 0x0 0x0 0x0>;
-				#address-cells = <3>;
-				#size-cells = <2>;
-				device_type = "pci";
-				ranges;
-			};
-		};
-	};
-};
-
 &pm7325_gpios {
 	kypd_vol_up_n: kypd-vol-up-n-state {
 		pins = "gpio6";
@@ -946,38 +850,6 @@
 		power-source = <1>;
 		bias-pull-up;
 		input-enable;
-	};
-};
-
-&pm8350c_gpios {
-	ntn_0p9_en: ntn-0p9-en-state {
-		pins = "gpio2";
-		function = "normal";
-
-		bias-disable;
-		input-disable;
-		output-enable;
-		power-source = <0>;
-	};
-
-	ntn_1p8_en: ntn-1p8-en-state {
-		pins = "gpio3";
-		function = "normal";
-
-		bias-disable;
-		input-disable;
-		output-enable;
-		power-source = <0>;
-	};
-
-	tc9563_rsex_n: tc9563-resx-state {
-		pins = "gpio1";
-		function = "normal";
-
-		bias-disable;
-		input-disable;
-		output-enable;
-		power-source = <0>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
+++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
@@ -2429,7 +2429,7 @@
 
 			status = "disabled";
 
-			pcie@0 {
+			pcie1_port0: pcie@0 {
 				device_type = "pci";
 				reg = <0x0 0x0 0x0 0x0 0x0>;
 				bus-range = <0x01 0xff>;

--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
+++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
@@ -2429,7 +2429,7 @@
 
 			status = "disabled";
 
-			pcie1_port0: pcie@0 {
+			pcie@0 {
 				device_type = "pci";
 				reg = <0x0 0x0 0x0 0x0 0x0>;
 				bus-range = <0x01 0xff>;


### PR DESCRIPTION
Backport latest applied dt changes for pcie switch from upstream and revert existing fromlist patch.

CRs-Fixed: 4426250