### PR TITLE
FROMLIST: drm/msm/dsi/phy: fix rounding error in recalc_rate

### DIFF
--- a/drivers/gpu/drm/msm/dsi/phy/dsi_phy_7nm.c
+++ b/drivers/gpu/drm/msm/dsi/phy/dsi_phy_7nm.c
@@ -595,6 +595,12 @@ static unsigned long dsi_pll_7nm_vco_recalc_rate(struct clk_hw *hw,
 	pll_freq += div_u64(tmp64, multiplier);
 
 	vco_rate = pll_freq;
+	/*
+	 * Recalculating the rate from dec and frac doesn't end up the rate
+	 * we originally set. Convert the freq to KHz, round it up and
+	 * convert it back to Hz.
+	 */
+	vco_rate = DIV_ROUND_UP_ULL(vco_rate, 1000) * 1000;
 	pll_7nm->vco_current_rate = vco_rate;
 
 	DBG("DSI PLL%d returning vco rate = %lu, dec = %x, frac = %x",


### PR DESCRIPTION
Required vco rate is set by programming decimal and fraction from 64 bit calculation. This programmed rate is not exactly matching the requested rate and corresponding recalc_rate is having rounding error due to this delta.

When setting byte_clk and byte_intf_clk from this pll, set_rate on byte_intf_clk resulting in dividers getting reprogrammed, which are already set from byte_clk. Convert this recalc_rate to KHz and back to Hz to round up this delta in calculation.

CRs-Fixed: 4255804
Link: https://lore.kernel.org/all/20251125-msm-dsi-phy-7nm-clk-rate-v1-1-17141806e3a0@oss.qualcomm.com/