### PR TITLE
FROMLIST: net: phy: qcom: qca808x: Add .get_rate_matching support

### DIFF
--- a/drivers/net/phy/qcom/qca808x.c
+++ b/drivers/net/phy/qcom/qca808x.c
@@ -643,6 +643,15 @@ static void qca808x_get_phy_stats(struct phy_device *phydev,
 	qcom_phy_get_stats(stats, priv->hw_stats);
 }
 
+static int qca808x_get_rate_matching(struct phy_device *phydev,
+				     phy_interface_t iface)
+{
+	if (iface == PHY_INTERFACE_MODE_2500BASEX)
+		return RATE_MATCH_PAUSE;
+
+	return RATE_MATCH_NONE;
+}
+
 static struct phy_driver qca808x_driver[] = {
 {
 	/* Qualcomm QCA8081 */
@@ -674,6 +683,7 @@ static struct phy_driver qca808x_driver[] = {
 	.led_polarity_set	= qca808x_led_polarity_set,
 	.update_stats		= qca808x_update_stats,
 	.get_phy_stats		= qca808x_get_phy_stats,
+	.get_rate_matching      = qca808x_get_rate_matching,
 }, };
 
 module_phy_driver(qca808x_driver);


### PR DESCRIPTION
IQ8 and IQ9 currently report support for only 2.5G due to a design mismatch between the QCA808X PHY and the stmmac MAC drivers. Historically, the stmmac driver has not supported dynamic switching of PHY interface modes, whereas the QCA808X requires switching between 2500BASE-X and SGMII for proper operation at lower link speeds.
Although the upstream community previously NACKed this specific change, a broader PCS rework is underway, and there is active discussion to properly address this behavior. Relevant discussions and context are shared in the links below, along with the associated QLIJIRA for exception approval.

QLIJIRA: QLIJIRA-100
QLI0.0-PR: https://github.com/qualcomm-linux/kernel-topics/pull/642
CRs-Fixed: 4432813
Link: https://lore.kernel.org/netdev/20250914-qca808x_rate_match-v1-1-0f9e6a331c3b@oss.qualcomm.com/T/#u
Link: https://lore.kernel.org/netdev/aX4v499Zz0CymZI5@oss.qualcomm.com/#t
Link: https://lore.kernel.org/netdev/aXsLyb+x76%2FWaXcs@oss.qualcomm.com/