### PR TITLE
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Enable USB2 controller Micro-USB OTG

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -255,6 +255,16 @@
 		};
 	};
 
+	vdd_micro_usb_vbus: regulator-micro-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "MICRO_USB_VBUS";
+		gpio = <&tlmm 63 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		enable-active-high;
+	};
+
 	vph_pwr: vph-pwr-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vph_pwr";
@@ -284,6 +294,31 @@
 		pinctrl-0 = <&ntn_1p8_en>;
 		pinctrl-names = "default";
 		regulator-enable-ramp-delay = <10000>;
+	};
+
+	usb2-connector {
+		compatible = "gpio-usb-b-connector",
+			     "usb-b-connector";
+			label = "micro-USB";
+			type = "micro";
+			id-gpios = <&tlmm 61 GPIO_ACTIVE_HIGH>;
+			vbus-gpios = <&pm7325_gpios 9 GPIO_ACTIVE_HIGH>;
+			vbus-supply = <&vdd_micro_usb_vbus>;
+			pinctrl-0 = <&usb2_id_detect>;
+			pinctrl-names = "default";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+
+					usb2_connector_ep: endpoint {
+						remote-endpoint = <&usb2_controller_ep>;
+					};
+				};
+			};
 	};
 
 	wcn6750-pmu {
@@ -1646,6 +1681,12 @@
 		 */
 		bias-pull-up;
 	};
+
+	usb2_id_detect: usb2-id-detect-state {
+		pins = "gpio61";
+		function = "gpio";
+		bias-pull-up;
+	};
 };
 
 &uart5 {
@@ -1705,6 +1746,31 @@
 	vdda-pll-supply = <&vreg_l1b_0p912>;
 
 	orientation-switch;
+
+	status = "okay";
+};
+
+&usb_2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+
+			usb2_controller_ep: endpoint {
+				remote-endpoint = <&usb2_connector_ep>;
+			};
+		};
+	};
+};
+
+&usb_2_hsphy {
+	vdda-pll-supply = <&vreg_l10c_0p88>;
+	vdda18-supply = <&vreg_l1c_1p8>;
+	vdda33-supply = <&vreg_l2b_3p072>;
 
 	status = "okay";
 };


### PR DESCRIPTION
    Enable the secondary USB controller (USB2) and its High-Speed PHY to
    support OTG functionality via a Micro-USB connector.

    Define a dedicated 'usb2-connector' node using the 'gpio-usb-b-connector'
    compatible to handle ID and VBUS detection. Link this connector to the
    DWC3 controller via OF graph ports to satisfy schema requirements and
    enable role switching.

    Specific hardware configuration:
    - ID pin: TLMM 61
    - VBUS detection: PM7325 GPIO 9
    - VBUS supply: Fixed regulator controlled by TLMM 63
    - Configure &usb_2 in OTG mode with role switching enabled.
    - Define a gpio-usb-b-connector node for Micro-USB support, mapping the
      ID pin to TLMM 61 and VBUS detection to PM7325 GPIO 9.
    - Add the 'vdd_micro_usb_vbus' fixed regulator (controlled by TLMM 63) to
      supply VBUS to the connector.
    - Add the 'usb2_id_detect' pinctrl state to configure GPIO 61 for ID
      detection.
    - Enable &usb_2_hsphy and populate necessary voltage supplies (VDDA PLL,
      VDDA 1.8V, VDDA 3.3V).

    Link: https://lore.kernel.org/all/c3on5e56hqipudpt7uyam2cples3rhadpz324zeg7nebczsglt@bxuy5jzrxjc7/
    Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
    Signed-off-by: Akash Kumar <akash.kumar@oss.qualcomm.com>
    
    CRs-Fixed: 4425508