### PR TITLE
Add camx el2 DT overlay for lemans/sa8775p platforms.

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -395,6 +395,10 @@ lemans-evk-camx-dtbs	:= lemans-evk.dtb lemans-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= lemans-evk-camx.dtb
 
+lemans-camx-el2-dtbs	:= lemans-evk-el2.dtb lemans-evk-camx.dtbo lemans-camx-el2.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= lemans-camx-el2.dtb
+
 monaco-evk-camx-dtbs   := monaco-evk.dtb monaco-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += monaco-evk-camx.dtb

--- a/arch/arm64/boot/dts/qcom/lemans-camx-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/lemans-camx-el2.dtso
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	/* cam_cpas label -> /soc@0/qcom,cam-cpas *
+	fragment@0 {
+		target-path = "/soc@0/qcom,cam-cpas";
+		__overlay__ {
+			enable-secure-qos-update = <0>;
+		};
+	};
+
+	/* cam_icp_firmware label -> /soc@0/qcom,cam-icp */
+	fragment@1 {
+		target-path = "/soc@0/qcom,cam-icp";
+		__overlay__ {
+			camera-firmware {
+				iommus = <&apps_smmu 0x08c1 0x0400>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The overlay updates the ICP firmware node with Secure SMMU SID and disables secure QoS updates for CPAS in EL2/KVM configurations. Wire up the new overlay-built DTBs in the qcom DT Makefile so the corresponding *-camx-el2.dtb targets are generated.

CRs-Fixed: 4439794