### PR TITLE
PENDING: arm64: dts: qcom: Add EL2 support for Iris for lemans

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/lemans-el2.dtso
@@ -15,8 +15,9 @@
 };
 
 &iris {
-	/* More driver work is needed */
-	status = "disabled";
+	video-firmware {
+		iommus = <&apps_smmu 0x0882 0x0400>;
+	};
 };
 
 /*


### PR DESCRIPTION
Add support for IRIS on lemans when Linux host running at EL2.

Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109

CRs-Fixed: 4345867