### PR TITLE
WORKAROUND: scsi: ufs: core: Set uic_cmd_timeout to max

### DIFF
--- a/drivers/ufs/core/ufshcd.c
+++ b/drivers/ufs/core/ufshcd.c
@@ -117,7 +117,7 @@ static bool is_mcq_supported(struct ufs_hba *hba)
 module_param(use_mcq_mode, bool, 0644);
 MODULE_PARM_DESC(use_mcq_mode, "Control MCQ mode for controllers starting from UFSHCI 4.0. 1 - enable MCQ, 0 - disable MCQ. MCQ is enabled by default");
 
-static unsigned int uic_cmd_timeout = UIC_CMD_TIMEOUT_DEFAULT;
+static unsigned int uic_cmd_timeout = UIC_CMD_TIMEOUT_MAX;
 
 static int uic_cmd_timeout_set(const char *val, const struct kernel_param *kp)
 {


### PR DESCRIPTION
It is obsrved that qcs9100-ride fails to boot
intermittently due to ufs cmd timeouts.

The timeout happens as the ufs threaded-irq fails to schedule within the default UIC_CMD_TIMEOUT_DEFAULT (500 msec) due to console logs spewing at the same moment.

Increase timeout to max for now to UIC_CMD_TIMEOUT_MAX (5000 msecs) to allow ufs cmd sequences to complete.
CRs-Fixed: 4442003