### PR TITLE
BACKPORT: arm64: dts: qcom: qcs615: Update 'model' string for qcs615 ride

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs615-ride.dts
+++ b/arch/arm64/boot/dts/qcom/qcs615-ride.dts
@@ -10,7 +10,7 @@
 #include "talos.dtsi"
 #include "pm8150.dtsi"
 / {
-	model = "Qualcomm Technologies, Inc. QCS615 Ride";
+	model = "Qualcomm Technologies, Inc. QCS615 Ride (IQ-615 Beta EVK)";
 	compatible = "qcom,qcs615-ride", "qcom,qcs615", "qcom,sm6150";
 	chassis-type = "embedded";
 


### PR DESCRIPTION
Update 'model' string for qcs615 ride

Update the 'model' property in the QCS615-ride device tree to include the public board name "IQ-615 Beta EVK". This ensures consistency with official documentation and release notes.


Link: https://lore.kernel.org/all/20251029023137.381386-1-xin.liu@oss.qualcomm.com/

CRs-Fixed: 4440512