### PR TITLE
FROMLIST: drm/msm: enable separate_gpu_kms by default

### DIFF
--- a/drivers/gpu/drm/msm/msm_drv.c
+++ b/drivers/gpu/drm/msm/msm_drv.c
@@ -54,7 +54,7 @@ static bool modeset = true;
 MODULE_PARM_DESC(modeset, "Use kernel modesetting [KMS] (1=on (default), 0=disable)");
 module_param(modeset, bool, 0600);
 
-static bool separate_gpu_kms;
+static bool separate_gpu_kms = true;
 MODULE_PARM_DESC(separate_gpu_drm, "Use separate DRM device for the GPU (0=single DRM device for both GPU and display (default), 1=two DRM devices)");
 module_param(separate_gpu_kms, bool, 0400);
 


### PR DESCRIPTION
On targets with multiple display subsystems, such as SA8775P, the GPU binds to the first display subsystem that probes. This implicit binding prevents subsequent display subsystems from probing successfully, breaking multi-display support.

Enable separate_gpu_kms by default to decouple GPU and display subsystem probing. This allows each display subsystem to initialize independently, ensuring that all display subsystems are probed.

CRs-Fixed: 4443714