### PR TITLE
FROMLIST: arm64: dts: qcom: hamoa: Add PSCI SYSTEM_RESET2 types

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -450,6 +450,11 @@
 			#power-domain-cells = <0>;
 			/* TODO: system-wide idle states */
 		};
+
+		reboot-mode {
+			mode-bootloader = <0x80010001 0x2>;
+			mode-edl = <0x80000000 0x1>;
+		};
 	};
 
 	reserved-memory {


### PR DESCRIPTION
Add support for SYSTEM_RESET2 vendor-specific resets as reboot-modes in the psci node.  Describe the resets: "bootloader" will cause device to reboot and stop in the bootloader's fastboot mode.  "edl" will cause device to reboot into "emergency download mode", which permits loading images via the Firehose protocol.


Link: https://lore.kernel.org/all/20260226054113.4156874-1-xin.liu@oss.qualcomm.com/

CRs-Fixed: 4453237