### PR TITLE
arm64: dts: qcom: qcs6490-rb3gen2: use DP controller native…

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -49,8 +49,6 @@
 		label = "DP";
 		type = "mini";
 
-		hpd-gpios = <&tlmm 60 GPIO_ACTIVE_HIGH>;
-
 		port {
 			dp_connector_in: endpoint {
 				remote-endpoint = <&mdss_edp_out>;
@@ -1754,7 +1752,6 @@
 /* PINCTRL - ADDITIONS TO NODES IN PARENT DEVICE TREE FILES */
 
 &edp_hot_plug_det {
-	function = "gpio";
 	bias-disable;
 };
 


### PR DESCRIPTION
The base device tree configures the edp_hot_plug_det pin using the
"edp_hot" function on GPIO 60. However, on qcs6490-rb3gen2 this external
HPD GPIO does not generate a connect event when a display is already
connected at boot, causing the DP/eDP display to remain disabled.

The DP controller’s native HPD correctly detects the connected sink
in this scenario, so continue using the DP controller native HPD
on the qcs6490-rb3gen2 platform instead of the external HPD GPIO.

CRs-Fixed: 4442506