### PR TITLE
arm64: dts: qcom: add staging DT overlays for QPS615 enablement

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -429,6 +429,8 @@ monaco-camx-el2-dtbs	:= monaco-evk-el2.dtb monaco-evk-camx.dtbo monaco-camx-el2.
 
 dtb-$(CONFIG_ARCH_QCOM)	+= monaco-camx-el2.dtb
 
+dtb-$(CONFIG_ARCH_QCOM)	+= monaco-evk-staging.dtbo
+
 qcs615-ride-camx-dtbs	:= qcs615-ride.dtb qcs615-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride-camx.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -419,6 +419,8 @@ lemans-camx-el2-dtbs	:= lemans-evk-el2.dtb lemans-evk-camx.dtbo lemans-camx-el2.
 
 dtb-$(CONFIG_ARCH_QCOM)	+= lemans-camx-el2.dtb
 
+dtb-$(CONFIG_ARCH_QCOM)	+= lemans-evk-staging.dtbo
+
 monaco-evk-camx-dtbs   := monaco-evk.dtb monaco-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += monaco-evk-camx.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -440,6 +440,8 @@ qcs6490-rb3gen2-vision-mezzanine-camx-dtbs := qcs6490-rb3gen2-vision-mezzanine.d
 
 dtb-$(CONFIG_ARCH_QCOM) += qcs6490-rb3gen2-vision-mezzanine-camx.dtb
 
+dtb-$(CONFIG_ARCH_QCOM)	+= qcs6490-rb3gen2-staging.dtbo
+
 qcs8300-ride-camx-dtbs:= qcs8300-ride.dtb qcs8300-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += qcs8300-ride-camx.dtb

--- a/arch/arm64/boot/dts/qcom/lemans-evk-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/lemans-evk-staging.dtso
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&i2c18 {
+	eeprom@52 {
+		nvmem-layout {
+			mac_addr2: mac-addr@6 {
+				reg = <0x6 0x6>;
+			};
+			mac_addr3: mac-addr@c {
+				reg = <0xc 0x6>;
+			};
+		};
+	};
+};
+
+&pcieport0 {
+	pcie@0,0 {
+		pcie@3,0 {
+			pci@0,0 {
+				interrupts-extended = <&tlmm 56 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				nvmem-cells = <&mac_addr2>;
+				nvmem-cell-names = "mac-address";
+				pinctrl-names = "default";
+				pinctrl-0 = <&aqr_intn_wol_sig>;
+				phy-reset-gpios = <&tlmm 76 GPIO_ACTIVE_HIGH>;
+				reset-deassert-us = <221000>;
+			};
+
+			pci@0,1 {
+				interrupts-extended = <&tlmm 57 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				nvmem-cells = <&mac_addr3>;
+				nvmem-cell-names = "mac-address";
+				pinctrl-names = "default";
+				pinctrl-0 = <&napa_intn_wol_sig>;
+				phy-reset-gpios = <&tlmm 77 GPIO_ACTIVE_HIGH>;
+				reset-deassert-us = <20000>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	qps615_intn_wol {
+		aqr_intn_wol_sig: aqr-intn-wol-sig {
+			pins = "gpio56";
+			function = "gpio";
+			input-enable;
+			bias-disable;
+		};
+		napa_intn_wol_sig: napa-intn-wol-sig {
+			pins = "gpio57";
+			function = "gpio";
+			input-enable;
+			bias-disable;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/monaco-evk-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-staging.dtso
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&eeprom1 {
+	nvmem-layout {
+		mac_addr1: mac-addr@0 {
+			reg = <0x0 0x6>;
+		};
+
+		mac_addr2: mac-addr@6 {
+			reg = <0x6 0x6>;
+		};
+	};
+};
+
+&pcieport0 {
+	pcie@0,0 {
+		pcie@3,0 {
+			pci@0,0 {
+				interrupts-extended = <&tlmm 40 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				nvmem-cells = <&mac_addr1>;
+				nvmem-cell-names = "mac-address";
+				pinctrl-names = "default";
+				pinctrl-0 = <&aqr_intn_wol_sig>;
+				phy-reset-gpios = <&tlmm 10 GPIO_ACTIVE_HIGH>;
+				reset-deassert-us = <221000>;
+			};
+
+			pci@0,1 {
+				interrupts-extended = <&tlmm 39 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				nvmem-cells = <&mac_addr2>;
+				nvmem-cell-names = "mac-address";
+				pinctrl-names = "default";
+				pinctrl-0 = <&napa_intn_wol_sig>;
+				phy-reset-gpios = <&expander5 0 GPIO_ACTIVE_HIGH>;
+				reset-deassert-us = <20000>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	qps615_intn_wol {
+		aqr_intn_wol_sig: aqr-intn-wol-sig {
+			pins = "gpio40";
+			function = "gpio";
+			input-enable;
+			bias-disable;
+		};
+
+		napa_intn_wol_sig: napa-intn-wol-sig {
+			pins = "gpio39";
+			function = "gpio";
+			input-enable;
+			bias-disable;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-staging.dtso
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	qep_vreg: qep_vreg {
+		compatible = "regulator-fixed";
+		regulator-name = "qep_vreg";
+		gpio = <&pm7325_gpios 8 0>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+	};
+
+	aqr_vreg: aqr_vreg {
+		compatible = "regulator-fixed";
+		regulator-name = "aqr_vreg";
+		gpio = <&pm7250b_gpios 4 0>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+	};
+};
+
+&pcie1_port0 {
+	pcie@0,0 {
+		pcie@3,0 {
+			/*
+			 * PF0: also acts as the QPS615 GPIO controller.
+			 * gpio-controller / #gpio-cells expose the TC956X
+			 * internal GPIO lines (hardware numbers 0-13) so that
+			 * phy-reset-gpios can reference them.
+			 */
+			qps615: pci@0,0 {
+				interrupts-extended = <&tlmm 141 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				phy-supply = <&aqr_vreg>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&aqr_intn_wol_sig>;
+				phy-reset-gpios = <&qps615 0 GPIO_ACTIVE_LOW>;
+				reset-deassert-us = <221000>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			pci@0,1 {
+				interrupts-extended = <&tlmm 101 IRQ_TYPE_EDGE_FALLING>;
+				interrupt-names = "wol_irq";
+				phy-supply = <&qep_vreg>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&napa_intn_wol_sig>;
+				phy-reset-gpios = <&qps615 1 GPIO_ACTIVE_LOW>;
+				reset-deassert-us = <20000>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	qps615_intn_wol {
+		aqr_intn_wol_sig: aqr_intn_wol_sig {
+			mux {
+				pins = "gpio141";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio141";
+				input-enable;
+				bias-disable;
+			};
+		};
+
+		napa_intn_wol_sig: napa_intn_wol_sig {
+			mux {
+				pins = "gpio101";
+				function = "gpio";
+			};
+
+			config {
+				pins = "gpio101";
+				input-enable;
+				bias-disable;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add temporary, board‑specific Device Tree overlays to enable the QPS615 PCIe switch Ethernet ports (10GbE + 2.5GbE) without modifying existing base DTBs.

This PR introduces DTBO‑only “staging” overlays for:
- Lemans EVK IFP Mezz
- Monaco EVK IFP Mezz
- Rb3Gen2 (QCS6490)

The overlays wire up PCIe endpoints, WoL interrupts, PHY resets, regulators (where required), and MAC address provisioning. These overlays are intended as a short‑term workaround and will be removed once native upstream driver support lands.

**QLI Mainline PR**: https://github.com/qualcomm-linux/kernel-topics/pull/909
**Exception details**: Until the QPS615 driver is upstreamed (third party ETA: end of 2026), an exception has been approved to include the driver and its devicetree entries as an out of tree DLKM only for QLI 2.0. (QLIJIRA-99, QLIJIRA-104).

CRs-Fixed: 4494593