### PR TITLE
FROMLIST: arm64: dts: qcom: hamoa-iot-evk: support Bluetooth over both USB and UART

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
@@ -620,10 +620,9 @@
 		vddrfa1p2-supply = <&vreg_wcn_1p9>;
 		vddrfa1p8-supply = <&vreg_wcn_1p9>;
 
-		bt-enable-gpios = <&tlmm 116 GPIO_ACTIVE_HIGH>;
 		wlan-enable-gpios = <&tlmm 117 GPIO_ACTIVE_HIGH>;
 
-		pinctrl-0 = <&wcn_bt_en>, <&wcn_wlan_en>;
+		pinctrl-0 = <&wcn_wlan_en>;
 		pinctrl-names = "default";
 
 		regulators {
@@ -1315,11 +1314,12 @@
 		output-low;
 	};
 
-	wcn_bt_en: wcn-bt-en-state {
-		pins = "gpio116";
-		function = "gpio";
-		drive-strength = <2>;
-		bias-disable;
+	wcn_bt_en_hog: wcn-bt-en-state-hog {
+		gpio-hog;
+		gpios = <116 GPIO_ACTIVE_HIGH>;
+		output-high;
+		input-disable;
+		line-name = "BT_EN";
 	};
 
 	wcn_wlan_en: wcn-wlan-en-state {


### PR DESCRIPTION
When Bluetooth supports both USB and UART, the BT UART driver is always loaded, while USB is hot-pluggable. As a result, when Bluetooth is used over USB, the UART driver still be probed and drive BT_EN low, which causes the Bluetooth device on USB to be disconnected.

Configure BT_EN as a GPIO hog so that it is controlled by the platform instead of the UART driver, preventing BT over USB from being unintentionally powered down.

Link: https://lore.kernel.org/all/20260311090921.1892191-1-shuai.zhang@oss.qualcomm.com/
CRs-Fixed: 4464912