### PR TITLE
QCLINUX: ARM: dts: msm: add rpi panel support for IQ9 board

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -20,8 +20,24 @@
 	aliases {
 		ethernet0 = &ethernet0;
 		mmc1 = &sdhc;
+		i2c1 = &i2c1;
 		serial0 = &uart10;
 		serial1 = &uart17;
+	};
+
+	display_bl: backlight {
+		compatible = "pwm-backlight";
+		power-supply = <&reg_dsi_touch>;
+		pwms = <&reg_backlight 0 255 0>;
+	};
+
+	reg_dsi_touch: regulator-touch {
+		compatible = "regulator-fixed";
+		regulator-name = "rpi-dsi-touch";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&expander3 1 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 
 	dmic: audio-codec-0 {
@@ -601,6 +617,21 @@
 	firmware-name = "qcom/sa8775p/a663_zap.mbn";
 };
 
+&i2c1 {
+	qcom,load-firmware;
+	qcom,xfer-mode = <1>;
+
+	status = "okay";
+
+	reg_backlight: reg_backlight@45 {
+		compatible = "raspberrypi,touchscreen-panel-regulator-v2";
+		reg = <0x45>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#pwm-cells = <3>;
+	};
+};
+
 &i2c11 {
 	status = "okay";
 
@@ -804,6 +835,36 @@
 	vdda-phy-supply = <&vreg_l1c>;
 	vdda-pll-supply = <&vreg_l4a>;
 
+	status = "okay";
+};
+
+&mdss0_dsi0 {
+	vdda-supply = <&vreg_l1c>;
+	status = "okay";
+
+	panel:panel@0 {
+		compatible = "raspberrypi,dsi-7inch";
+		reg = <0>;
+
+		reset-gpios = <&reg_backlight 0 GPIO_ACTIVE_LOW>;
+		power-supply = <&reg_dsi_touch>;
+		backlight = <&display_bl>;
+
+		port {
+			panel0_in: endpoint {
+				remote-endpoint = <&mdss0_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss0_dsi0_out {
+	remote-endpoint = <&panel0_in>;
+	data-lanes = <0 1>;
+};
+
+&mdss0_dsi0_phy {
+	vdds-supply = <&vreg_l4a>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add panel and corresponding regulator nodes.