### PR TITLE
Fix comment typo in camx EL2 dtso.

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-camx-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/lemans-camx-el2.dtso
@@ -7,7 +7,6 @@
 /plugin/;
 
 / {
-	/* cam_cpas label -> /soc@0/qcom,cam-cpas *
 	fragment@0 {
 		target-path = "/soc@0/qcom,cam-cpas";
 		__overlay__ {
@@ -15,7 +14,6 @@
 		};
 	};
 
-	/* cam_icp_firmware label -> /soc@0/qcom,cam-icp */
 	fragment@1 {
 		target-path = "/soc@0/qcom,cam-icp";
 		__overlay__ {


### PR DESCRIPTION
Fix a typo in the camx EL2 device tree by properly closing the comment line. The mistake was masked by a later comment terminator.

CRs-Fixed: 4439794