### PR TITLE
FROMLIST: driver: bluetooth:btusb: Allow firmware re-download when version matches

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -3466,7 +3466,10 @@ static int btusb_setup_qca_load_rampatch(struct hci_dev *hdev,
 		    "firmware rome 0x%x build 0x%x",
 		    rver_rom, rver_patch, ver_rom, ver_patch);
 
-	if (rver_rom != ver_rom || rver_patch <= ver_patch) {
+	/* Allow rampatch if version is greater than or equal to firmware version.
+	 * Equal versions are acceptable for re-flashing or recovery scenarios.
+	 */
+	if (rver_rom != ver_rom || rver_patch < ver_patch) {
 		bt_dev_err(hdev, "rampatch file version did not match with firmware");
 		err = -EINVAL;
 		goto done;


### PR DESCRIPTION
Since USB can disconnect at any time, if it disconnects during the BT firmware download, the BT controller firmware version may still be updated even without completing the download.

When USB reconnects, the BT host detects the same version as in the firmware file, which prevents the firmware from being downloaded again.

Therefore, remove the equality check to ensure that after USB reconnection, the BT host can still download the firmware.

CRs-Fixed: 4436232