### PR TITLE
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2-industrial-mezzanine: Disable WCN6750 and WPSS

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
@@ -32,6 +32,10 @@
 	};
 };
 
+&remoteproc_wpss {
+       status = "disabled";
+};
+
 &spi11 {
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -279,4 +283,8 @@
 		output-enable;
 	};
 
+};
+
+&wifi {
+       status = "disabled";
 };


### PR DESCRIPTION
On the RB3 Gen2 industrial mezzanine platform, since PCIe0 now routes to
TC9563 instead of WCN6750, disable the WCN6750 and WPSS device tree nodes
to reflect the actual hardware configuration and avoid probing issues.

Signed-off-by: Hangtian Zhu <hangtian@oss.qualcomm.com>
Signed-off-by: Sushrut Shree Trivedi <sushrut.trivedi@oss.qualcomm.com>
Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
Reviewed-by: Konrad Dybcio <konrad.dybcio@oss.qualcomm.com>
Link: https://lore.kernel.org/all/20260317-industrial-mezzanine-pcie-v5-1-1358978517fe@oss.qualcomm.com/

CRs-Fixed: 4459835