### PR TITLE
WORKAROUND: remoteproc: qcom: Fix RB8 device hung issue

### DIFF
--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -184,6 +184,18 @@ static void qcom_pas_pds_disable(struct qcom_pas *pas, struct device **pds,
 	int i;
 
 	for (i = 0; i < pd_count; i++) {
+		/*
+		 * There is a race condition which occurs sometimes for RB8 platform when APPS
+		 * removes it's vote on handover INT from fw - ADSP F/W side vote is not yet
+		 * applied on the lcx and lmx rails because of which PMIC shutdowns shut and device
+		 * goes into hung state. Carry this WA until a proper fix is finalized.
+		 */
+		if (of_device_is_compatible(dev_of_node(pas->dev), "qcom,sa8775p-adsp-pas")) {
+			/* Apply SVS_L1 vote to keep lcx and lmx rails ON */
+			dev_pm_genpd_set_performance_state(pds[i], 192);
+			return;
+		}
+
 		dev_pm_genpd_set_performance_state(pds[i], 0);
 		pm_runtime_put(pds[i]);
 	}


### PR DESCRIPTION
A race condition is occasionally observed on the RB8 platform where the APPS processor removes its turbo vote from the LCX and LMX rails immediately after receiving the handover interrupt from firmware. At that moment, the ADSP firmware vote has not yet been applied to these rails, causing the PMIC shut down and leading the device to hang.

Keep the vote of lcx and lmx rails to SVS_L1 from APPS side instead of completely removing it as a WA until actual fix is available.

CRs-Fixed: 4474556