### PR TITLE
QCLINUX: arm64: dts: qcom: monaco: Add CamX EL2 overlay

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -411,6 +411,10 @@ monaco-evk-camx-dtbs   := monaco-evk.dtb monaco-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += monaco-evk-camx.dtb
 
+monaco-camx-el2-dtbs	:= monaco-evk-el2.dtb monaco-evk-camx.dtbo monaco-camx-el2.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= monaco-camx-el2.dtb
+
 qcs615-ride-camx-dtbs	:= qcs615-ride.dtb qcs615-ride-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcs615-ride-camx.dtb

--- a/arch/arm64/boot/dts/qcom/monaco-camx-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-camx-el2.dtso
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/soc@0/qcom,cam-cpas";
+		__overlay__ {
+			enable-secure-qos-update = <0>;
+		};
+	};
+
+	fragment@1 {
+		target-path = "/soc@0/qcom,cam-icp";
+		__overlay__ {
+			camera-firmware {
+				iommus = <&apps_smmu 0x08c1 0x0400>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add camx el2 DT overlay for lemans platforms.

The overlay updates the ICP firmware node with Secure SMMU SID and disables secure QoS updates for CPAS in EL2/KVM configurations.

Wire up the new overlay-built DTBs in the qcom DT Makefile so the corresponding *-camx-el2.dtb targets are generated.

CRs-Fixed: 4439794