### PR TITLE
FROMLIST: coresight: platform: check the availability of the endpoint before parse

### DIFF
--- a/drivers/hwtracing/coresight/coresight-platform.c
+++ b/drivers/hwtracing/coresight/coresight-platform.c
@@ -220,6 +220,8 @@ static int of_coresight_parse_endpoint(struct device *dev,
 		rparent = of_coresight_get_port_parent(rep);
 		if (!rparent)
 			break;
+		if (!of_device_is_available(rparent))
+			break;
 		if (of_graph_parse_endpoint(rep, &rendpoint))
 			break;
 


### PR DESCRIPTION
Check endpoint availability before parsing it. If parsing a connected endpoint fails, the probe is deferred until the endpoint becomes available, or eventually fails. In some legacy cases, a replicator has two output ports where one is disabled and the other is available. The replicator probe always fails because the disabled endpoint never becomes available for parsing. In addition, there is no need to defer probing a device that is connected to a disabled device, which improves probe performance.

Link: https://lore.kernel.org/all/20260320-add-availability-check-v1-1-b2e39cdeb6e0@oss.qualcomm.com/
Reviewed-by: Leo Yan <leo.yan@arm.com>

CRs-Fixed: 4469888