### PR TITLE
FROMLIST: arm64: dts: qcom: talos: Add psci reboot-modes

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos.dtsi
+++ b/arch/arm64/boot/dts/qcom/talos.dtsi
@@ -625,6 +625,11 @@
 					      &cluster_sleep_1
 					      &cluster_sleep_2>;
 		};
+
+		reboot-mode {
+			mode-bootloader = <0x80010001 0x2>;
+			mode-edl = <0x80000000 0x1>;
+		};
 	};
 
 	reserved-memory {


### PR DESCRIPTION
Add PSCI SYSTEM_RESET2 reboot-modes for talos based boards, for use by the psci_reboot_mode driver.

The following modes are defined:
- bootloader: reboot into fastboot mode for fastboot flashing.
- edl: reboot into emergency download mode for image loading via the Firehose protocol.

Support for these modes is firmware dependent.

CRs-Fixed: 4476953