### PR TITLE
PENDING: arm64: dts: qcom: Add EL2 support for Iris for monaco

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-el2.dtso
@@ -13,7 +13,10 @@
 };
 
 &iris {
-	status = "disabled";
+	status = "okay";
+	video-firmware {
+		iommus = <&apps_smmu 0x0882 0x0400>;
+	};
 };
 
 &remoteproc_adsp {


### PR DESCRIPTION
Add support for IRIS on monaco when Linux host running at EL2.

Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109

CRs-Fixed: 4345867