### PR TITLE
FROMLIST: media: qcom: venus: drop extra padding in NV12 raw size cal…

### DIFF
--- a/drivers/media/platform/qcom/venus/helpers.c
+++ b/drivers/media/platform/qcom/venus/helpers.c
@@ -954,8 +954,8 @@ static u32 get_framesize_raw_nv12(u32 width, u32 height)
 	uv_sclines = ALIGN(((height + 1) >> 1), 16);
 
 	y_plane = y_stride * y_sclines;
-	uv_plane = uv_stride * uv_sclines + SZ_4K;
-	size = y_plane + uv_plane + SZ_8K;
+	uv_plane = uv_stride * uv_sclines;
+	size = y_plane + uv_plane;
 
 	return ALIGN(size, SZ_4K);
 }


### PR DESCRIPTION
The NV12 frame size calculation adds unnecessary 4K/8K padding, leading to buffer overallocation. The redundant padding is removed while keeping final 4K alignment.

CRs-Fixed: 4470055