### PR TITLE
bus: mhi: host: pci_generic: Improve boot performance and cleanup

### DIFF
--- a/drivers/bus/mhi/host/pci_generic.c
+++ b/drivers/bus/mhi/host/pci_generic.c
@@ -1446,6 +1446,7 @@ static void mhi_pci_remove(struct pci_dev *pdev)
 		mhi_soc_reset(mhi_cntrl);
 
 	mhi_unregister_controller(mhi_cntrl);
+	pm_runtime_forbid(&pdev->dev);
 }
 
 static void mhi_pci_shutdown(struct pci_dev *pdev)

--- a/drivers/bus/mhi/host/pci_generic.c
+++ b/drivers/bus/mhi/host/pci_generic.c
@@ -1392,7 +1392,7 @@ static int mhi_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		goto err_unregister;
 	}
 
-	err = mhi_sync_power_up(mhi_cntrl);
+	err = mhi_async_power_up(mhi_cntrl);
 	if (err) {
 		dev_err(&pdev->dev, "failed to power up MHI controller\n");
 		goto err_unprepare;


### PR DESCRIPTION
This series addresses boot performance issues with MHI PCI generic driver
and adds proper cleanup in the remove path.

Some modems like SDX75 take up to 20 seconds to initialize, which blocks
system boot while waiting for them to reach mission mode. The first patch
switches to async power up so the driver can return immediately and let
initialization happen in the background.

The second patch adds the missing pm_runtime_forbid() call in remove to
balance the pm_runtime_allow() from probe.

CRs-Fixed: 4468490