### PR TITLE
WORKAROUND: Disable PCIe ASPM on QCS6490 Industrial kit

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtso
@@ -102,6 +102,9 @@
 		pinctrl-0 = <&pcie0_tc9563_resx_n>;
 		pinctrl-names = "default";
 
+		aspm-no-l0s;
+		aspm-no-l1;
+
 		pcie@1,0 {
 			reg = <0x20800 0x0 0x0 0x0 0x0>;
 			#address-cells = <3>;
@@ -110,6 +113,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x3 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 		};
 
 		pcie@2,0 {
@@ -120,6 +126,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x4 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 		};
 
 		pcie@3,0 {
@@ -197,6 +206,9 @@
 		pinctrl-0 = <&pcie1_tc9563_resx_n>;
 		pinctrl-names = "default";
 
+		aspm-no-l0s;
+		aspm-no-l1;
+
 		pcie@1,0 {
 			reg = <0x40800 0x0 0x0 0x0 0x0>;
 			#address-cells = <3>;
@@ -205,6 +217,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x3 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 		};
 
 		pcie@2,0 {
@@ -215,6 +230,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x4 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 		};
 
 		pcie@3,0 {

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -1021,6 +1021,9 @@
 		pinctrl-0 = <&tc9563_resx_n>;
 		pinctrl-names = "default";
 
+		aspm-no-l0s;
+		aspm-no-l1;
+
 		pcie1_switch0_dsp1: pcie@1,0 {
 			reg = <0x20800 0x0 0x0 0x0 0x0>;
 			#address-cells = <3>;
@@ -1029,6 +1032,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x3 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 		};
 
 		pcie@2,0 {
@@ -1039,6 +1045,9 @@
 			device_type = "pci";
 			ranges;
 			bus-range = <0x4 0xff>;
+
+			aspm-no-l0s;
+			aspm-no-l1;
 
 			/* Renesas μPD720201 PCIe USB3.0 Host Controller */
 			usb-controller@0,0 {

--- a/drivers/pci/pcie/aspm.c
+++ b/drivers/pci/pcie/aspm.c
@@ -853,6 +853,18 @@ static void pcie_aspm_cap_init(struct pcie_link_state *link, int blacklist)
 					   parent_lnkctl & ~PCI_EXP_LNKCTL_ASPMC);
 	}
 
+	if (of_property_read_bool(child->dev.of_node, "aspm-no-l0s") ||
+	    of_property_read_bool(parent->dev.of_node, "aspm-no-l0s")) {
+		parent->aspm_l0s_support = 0;
+		child->aspm_l0s_support = 0;
+	}
+
+	if (of_property_read_bool(child->dev.of_node, "aspm-no-l1") ||
+	    of_property_read_bool(parent->dev.of_node, "aspm-no-l1")) {
+		parent->aspm_l1_support = 0;
+		child->aspm_l1_support = 0;
+	}
+
 	/*
 	 * Setup L0s state
 	 *


### PR DESCRIPTION
Enabling PCIe ASPM on the RB3gen2 Industrial kit causes PCIe link to go bad and endpoints also sometimes become inaccessible.
Take this fix as a workaround on qli2.0 while issue is being debugged.

CRs-Fixed: 4490067