### PR TITLE
FROMLIST: arm64: dts: qcom: kodiak: increase fastrpc compute-cb session slots

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak.dtsi
+++ b/arch/arm64/boot/dts/qcom/kodiak.dtsi
@@ -4465,6 +4465,7 @@
 						compatible = "qcom,fastrpc-compute-cb";
 						reg = <5>;
 						iommus = <&apps_smmu 0x1805 0x0>;
+						qcom,nsessions = <5>;
 						dma-coherent;
 					};
 				};


### PR DESCRIPTION
Some workloads on Kodiak can exhaust FastRPC sessions when multiple compute clients open contexts concurrently, leading to -EBUSY failures.

Describe the compute context bank with qcom,nsessions = <5> so the driver can provision enough session slots for the compute-cb instance.

Link: https://lore.kernel.org/all/20260401073345.478-1-jianping.li@oss.qualcomm.com/
CRs-Fixed: 4488683