### PR TITLE
FROMLIST: drm/display: add hw_params callback function to drm_connect…

### DIFF
--- a/drivers/gpu/drm/display/drm_hdmi_audio_helper.c
+++ b/drivers/gpu/drm/display/drm_hdmi_audio_helper.c
@@ -130,6 +130,7 @@ EXPORT_SYMBOL(drm_connector_hdmi_audio_plugged_notify);
 
 static const struct hdmi_codec_ops drm_connector_hdmi_audio_ops = {
 	.audio_startup = drm_connector_hdmi_audio_startup,
+	.hw_params = drm_connector_hdmi_audio_prepare,
 	.prepare = drm_connector_hdmi_audio_prepare,
 	.audio_shutdown = drm_connector_hdmi_audio_shutdown,
 	.mute_stream = drm_connector_hdmi_audio_mute_stream,


### PR DESCRIPTION
…or_hdmi_audio_ops

After reusing drm_hdmi_audio_* helpers and drm_bridge_connector integration in drm/msm/dp, we have dropped msm_dp_audio_hw_params and use msm_dp_audio_prepare instead. While userspace is still calling hw_params to do audio initialization, and we get the following errors:

q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: q6apm_lpass_dai_prepare() started
q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: q6apm_lpass_dai_prepare() started
q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: q6apm_lpass_dai_prepare() started
hdmi-audio-codec hdmi-audio-codec.0.auto: hdmi_codec_hw_params() started
q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: q6apm_lpass_dai_prepare() started
qcom-apm gprsvc:service:2:1: Error (1) Processing 0x01001002 cmd
qcom-apm gprsvc:service:2:1: DSP returned error[1001002] 1
q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: Failed to start APM port 104
q6apm-lpass-dais 3700000.remoteproc:glink-edge:gpr:service@1:bedais: ASoC error (-22): at snd_soc_dai_prepare() on DISPLAY_PORT_RX_0
MultiMedia2 Playback: ASoC error (-22): at dpcm_run_update_startup() on MultiMedia2 Playback

msm_dp_audio_prepare is not called because hdmi-codec driver only checks and runs hw_params before q6apm_lpass_dai_prepare(). This commit will add hw_params callback same as drm_connector_hdmi_audio_prepare, so that hdmi-codec driver can work with userspace alsa.

Tested with Radxa Dragon Q6A.

Link: https://lore.kernel.org/linux-arm-msm/20250925040530.20731-1-liujianfeng1994@gmail.com/
Fixes: 98a8920e7b07 ("drm/msm/dp: reuse generic HDMI codec implementation")

Tested-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>



CRs-Fixed: 4493138