### PR TITLE
QCLINUX: drm/msm: Fix MODULE_PARM_DESC compilation build error

### DIFF
--- a/drivers/gpu/drm/msm/msm_drv.c
+++ b/drivers/gpu/drm/msm/msm_drv.c
@@ -55,9 +55,7 @@ MODULE_PARM_DESC(modeset, "Use kernel modesetting [KMS] (1=on (default), 0=disab
 module_param(modeset, bool, 0600);
 
 static int separate_gpu_kms = -1;
-MODULE_PARM_DESC(separate_gpu_kms,
-		 "Use separate DRM device for the GPU (-1=auto (default), 0=single DRM
-device, 1=separate DRM devices)");
+MODULE_PARM_DESC(separate_gpu_kms, "Use separate DRM device for the GPU (-1=auto (default), 0=single DRM device, 1=separate DRM devices)");
 module_param(separate_gpu_kms, int, 0400);
 
 DECLARE_FAULT_ATTR(fail_gem_alloc);


### PR DESCRIPTION
This changes fixes 'commit 2cea4c70c125671d9cad3dda11950c83032687de ("drm/msm: Auto-detect separate GPU KMS mode based on HW topology")'

The MODULE_PARM_DESC for separate_gpu_kms was split across lines, causing a build faliure due to a newline in the string literal. Fix this by formatting the description on a single line.


CRs-Fixed: 4443714