### PR TITLE
Fix ICE reg size on Kodiak and SM8450 dts

### DIFF
--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
+++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
@@ -2578,7 +2578,7 @@
 		ice: crypto@1d88000 {
 			compatible = "qcom,sc7280-inline-crypto-engine",
 				     "qcom,inline-crypto-engine";
-			reg = <0 0x01d88000 0 0x8000>;
+			reg = <0 0x01d88000 0 0x18000>;
 			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
 				 <&gcc GCC_UFS_PHY_AHB_CLK>;
 			clock-names = "ice_core_clk",

--- a/arch/arm64/boot/dts/qcom/sm8450.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8450.dtsi
@@ -5348,7 +5348,7 @@
 		ice: crypto@1d88000 {
 			compatible = "qcom,sm8450-inline-crypto-engine",
 				     "qcom,inline-crypto-engine";
-			reg = <0 0x01d88000 0 0x8000>;
+			reg = <0 0x01d88000 0 0x18000>;
 			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
 				 <&gcc GCC_UFS_PHY_AHB_CLK>;
 			clock-names = "ice_core_clk",


### PR DESCRIPTION
Update ICE reg size for kodiak and sm8450.

Ice reg size for kodiak/sm8450 is currently written incorrectly and
doesn't match hardware specification. This series attempt to fix it.

Link: https://lore.kernel.org/linux-arm-msm/20260402-ice_dt_reg_fix-v1-0-74e4c2129238@oss.qualcomm.com/
qcom-next PR: https://github.com/qualcomm-linux/kernel-topics/pull/903
Signed-off-by: Kuldeep Singh [kuldeep.singh@oss.qualcomm.com](mailto:kuldeep.singh@oss.qualcomm.com)
Signed-off-by: Abhinaba Rakshit [abhinaba.rakshit@oss.qualcomm.com](mailto:abhinaba.rakshit@oss.qualcomm.com)
CRs-Fixed: 4495786