### PR TITLE
FROMLIST: arm64: dts: qcom: hamoa: Add remoteproc IOMMUS in EL2 devic…

### DIFF
--- a/arch/arm64/boot/dts/qcom/x1-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/x1-el2.dtso
@@ -48,6 +48,14 @@
 	status = "okay";
 };
 
+&remoteproc_adsp {
+	iommus = <&apps_smmu 0x1000 0x80>;
+};
+
+&remoteproc_cdsp {
+	iommus = <&apps_smmu 0x0c00 0x0>;
+};
+
 /*
  * The "SBSA watchdog" is implemented in software in Gunyah
  * and can't be used when running in EL2.


### PR DESCRIPTION
…e trees

All the existing variants Hamoa boards are using Gunyah hypervisor which means that, so far, Linux-based OS could only boot in EL1 on those devices. However, it is possible for us to boot Linux at EL2 on these devices [1].

When running under Gunyah, the remote processor firmware IOMMU streams are controlled by Gunyah. However, without Gunyah, the IOMMU is managed by the consumer of this DeviceTree. Therefore, describe the firmware streams for each remote processor.

Add remoteproc IOMMUS to the EL2 device trees to generate the corresponding -el2.dtb files.

[1]
https://docs.qualcomm.com/bundle/publicresource/topics/80-70020-4/boot-developer-touchpoints.html#uefi

Reviewed-by: Abel Vesa <abel.vesa@oss.qualcomm.com>

Link: https://lore.kernel.org/all/20260203063244.1498699-1-xin.liu@oss.qualcomm.com/

CRs-Fixed: 4495965