### PR TITLE
FROMLIST: arm64: dts: qcom: enable UARTs for robot expansion board

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -22,6 +22,7 @@
 		mmc1 = &sdhc;
 		serial0 = &uart10;
 		serial1 = &uart17;
+		serial2 = &uart0;
 	};
 
 	dmic: audio-codec-0 {
@@ -1072,6 +1073,10 @@
 		function = "gpio";
 		bias-pull-up;
 	};
+};
+
+&uart0 {
+	status = "okay";
 };
 
 &uart10 {

--- a/arch/arm64/boot/dts/qcom/monaco-evk.dts
+++ b/arch/arm64/boot/dts/qcom/monaco-evk.dts
@@ -22,6 +22,7 @@
 		i2c1 = &i2c1;
 		serial0 = &uart7;
 		serial1 = &uart2;
+		serial2 = &uart6;
 	};
 
 	chosen {
@@ -933,6 +934,10 @@
 		vddrfa1p2-supply = <&vreg_wcn_3p3>;
 		vddrfa1p8-supply = <&vreg_wcn_3p3>;
 	};
+};
+
+&uart6 {
+	status = "okay";
 };
 
 &uart7 {


### PR DESCRIPTION
The Qualcomm Lemans EVK and Monaco EVK boards expose a mezzanine
connector used by a motor control expansion board.

This expansion board hosts an MCU running NuttX and communicates with
Linux over UART, with all protocol handling done in userspace.

This series enables the required UARTs and assigns stable serial aliases
to ensure consistent device enumeration across platforms.

Link: https://lore.kernel.org/all/20260327083101.1343613-1-canfeng.zhuang@oss.qualcomm.com/

CRs-Fixed: 4497971