### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: Enable audio over DisplayPort

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -189,6 +189,22 @@
 				sound-dai = <&q6apm>;
 			};
 		};
+
+		dp0-dai-link {
+			link-name = "DisplayPort0 Playback";
+
+			cpu {
+				sound-dai = <&q6apmbedai DISPLAY_PORT_RX_0>;
+			};
+
+			codec {
+				sound-dai = <&mdss0_dp0>;
+			};
+
+			platform {
+				sound-dai = <&q6apm>;
+			};
+		};
 	};
 
 	vbus_supply_regulator_0: regulator-vbus-supply-0 {


### PR DESCRIPTION
Add dailinks for DISPLAY-PORT to enable audio functionality on edp0.

Link: https://lore.kernel.org/all/ce8ca265-24df-41e5-a763-f9475de2fa9b@oss.qualcomm.com/

CRs-Fixed: 4502072
 
Signed-off-by: Kumar Anurag <kumar.singh@oss.qualcomm.com>