### PR TITLE
Revert "FROMLIST: PCI: dwc: Remove MSI/MSIX capability if iMSI-RX is …

### DIFF
--- a/drivers/pci/controller/dwc/pcie-designware-host.c
+++ b/drivers/pci/controller/dwc/pcie-designware-host.c
@@ -1106,16 +1106,6 @@ int dw_pcie_setup_rc(struct dw_pcie_rp *pp)
 
 	dw_pcie_dbi_ro_wr_dis(pci);
 
-	/*
-	 * If iMSI-RX module is used as the MSI controller, remove MSI and
-	 * MSI-X capabilities from PCIe Root Ports to ensure fallback to INTx
-	 * interrupt handling.
-	 */
-	if (pp->has_msi_ctrl) {
-		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSI);
-		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSIX);
-	}
-
 	return 0;
 }
 EXPORT_SYMBOL_GPL(dw_pcie_setup_rc);


### PR DESCRIPTION
…used as MSI controller"

This is causing excessive logging on some targets.

[   51.975219][  T818] pcieport 0000:00:00.0: AER: Correctable error message received from 0000:01:00.0
[   51.990628][  T818] ath11k_pci 0000:01:00.0: PCIe Bus Error: severity=Correctable, type=Data Link Layer, (Transmitter ID)
[   52.001895][  T818] ath11k_pci 0000:01:00.0:   device [17cb:1103] error status/mask=00001000/0000e000
[   52.011381][  T818] ath11k_pci 0000:01:00.0:    [12] Timeout
[   52.018815][  T818] pcieport 0000:00:00.0: AER: Correctable error message received from 0000:01:00.0
[   52.028307][  T818] ath11k_pci 0000:01:00.0: PCIe Bus Error: severity=Correctable, type=Data Link Layer, (Transmitter ID)
[   52.039565][  T818] ath11k_pci 0000:01:00.0:   device [17cb:1103] error status/mask=00001000/0000e000
[   52.049033][  T818] ath11k_pci 0000:01:00.0:    [12] Timeout

Reverting the commit for now to unblock.

This reverts commit 46992e0024e09857484049e0cbe360b86bdbe8f3.

CRs-Fixed: 4504163