### PR TITLE
FROMLIST: phy: qcom: edp: Initialize swing_pre_emph_cfg for sc7280

### DIFF
--- a/drivers/phy/qualcomm/phy-qcom-edp.c
+++ b/drivers/phy/qualcomm/phy-qcom-edp.c
@@ -543,6 +543,7 @@ static const struct qcom_edp_phy_cfg sa8775p_dp_phy_cfg = {
 
 static const struct qcom_edp_phy_cfg sc7280_dp_phy_cfg = {
 	.aux_cfg = edp_phy_aux_cfg_v4,
+	.swing_pre_emph_cfg = &edp_phy_swing_pre_emph_cfg,
 	.ver_ops = &qcom_edp_phy_ops_v4,
 };
 


### PR DESCRIPTION
Aux timeout is observed on few monitors like Benq BL2420-T due to missing swing_pre_emph_cfg.
CRs-Fixed: 3833060
Link: https://lore.kernel.org/r/20260403-phy_for_next-v1-1-3d336b555019@oss.qualcomm.com