### PR TITLE
WORKAROUND: usb: host: xhci-pci-renesas: enable D3cold PME support

### DIFF
--- a/drivers/usb/host/xhci-pci-renesas.c
+++ b/drivers/usb/host/xhci-pci-renesas.c
@@ -636,6 +636,7 @@ xhci_pci_renesas_probe(struct pci_dev *dev, const struct pci_device_id *id)
 	if (retval)
 		return retval;
 
+	dev->pme_support = dev->pme_support | (1 << PCI_D3cold);
 	return xhci_pci_common_probe(dev, id);
 }
 


### PR DESCRIPTION
Set the PCI device PME support bit for D3cold in
xhci_pci_renesas_probe().

Without advertising D3cold PME capability, the PCI PM core may avoid putting the Renesas xHCI controller into D3cold, preventing the PCIe device from reaching the deepest low-power state during suspend/runtime PM.

Update dev->pme_support to include PCI_D3cold so the device is allowed to enter D3cold when appropriate.

Signed-off-by: Akash Kumar <akash.kumar@oss.qualcomm.com>

CRs-Fixed: 4495614