### PR TITLE
FROMLIST: PCI/pwrctrl: Do not try to power on/off devices that don't need pwrctrl

### DIFF
--- a/drivers/pci/pwrctrl/core.c
+++ b/drivers/pci/pwrctrl/core.c
@@ -9,6 +9,7 @@
 #include <linux/export.h>
 #include <linux/kernel.h>
 #include <linux/of.h>
+#include <linux/of_graph.h>
 #include <linux/of_platform.h>
 #include <linux/pci.h>
 #include <linux/pci-pwrctrl.h>
@@ -138,6 +139,48 @@ int devm_pci_pwrctrl_device_set_ready(struct device *dev,
 }
 EXPORT_SYMBOL_GPL(devm_pci_pwrctrl_device_set_ready);
 
+/*
+ * Check whether the pwrctrl device really needs to be created or not. The
+ * pwrctrl device will only be created if the node satisfies below requirements:
+ *
+ * 1. Presence of compatible property with "pci" prefix to match against the
+ *    pwrctrl driver (AND)
+ * 2. At least one of the power supplies defined in the devicetree node of the
+ *    device (OR) in the remote endpoint parent node to indicate pwrctrl
+ *    requirement.
+ */
+static bool pci_pwrctrl_is_required(struct device_node *np)
+{
+	struct device_node *endpoint;
+	const char *compat;
+	int ret;
+
+	ret = of_property_read_string(np, "compatible", &compat);
+	if (ret < 0)
+		return false;
+
+	if (!strstarts(compat, "pci"))
+		return false;
+
+	if (of_pci_supply_present(np))
+		return true;
+
+	if (of_graph_is_present(np)) {
+		for_each_endpoint_of_node(np, endpoint) {
+			struct device_node *remote __free(device_node) =
+				of_graph_get_remote_port_parent(endpoint);
+			if (remote) {
+				if (of_pci_supply_present(remote)) {
+					of_node_put(endpoint);
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
 static int __pci_pwrctrl_power_off_device(struct device *dev)
 {
 	struct pci_pwrctrl *pwrctrl = dev_get_drvdata(dev);
@@ -155,6 +198,9 @@ static void pci_pwrctrl_power_off_device(struct device_node *np)
 
 	for_each_available_child_of_node_scoped(np, child)
 		pci_pwrctrl_power_off_device(child);
+
+	if (!pci_pwrctrl_is_required(np))
+		return;
 
 	pdev = of_find_device_by_node(np);
 	if (!pdev)
@@ -211,6 +257,9 @@ static int pci_pwrctrl_power_on_device(struct device_node *np)
 		if (ret)
 			return ret;
 	}
+
+	if (!pci_pwrctrl_is_required(np))
+		return 0;
 
 	pdev = of_find_device_by_node(np);
 	if (!pdev)

--- a/include/linux/pci-pwrctrl.h
+++ b/include/linux/pci-pwrctrl.h
@@ -54,7 +54,7 @@ int pci_pwrctrl_device_set_ready(struct pci_pwrctrl *pwrctrl);
 void pci_pwrctrl_device_unset_ready(struct pci_pwrctrl *pwrctrl);
 int devm_pci_pwrctrl_device_set_ready(struct device *dev,
 				     struct pci_pwrctrl *pwrctrl);
-#if IS_ENABLED(CONFIG_PCI_PWRCTRL)
+#if IS_REACHABLE(CONFIG_PCI_PWRCTRL)
 int pci_pwrctrl_create_devices(struct device *parent);
 void pci_pwrctrl_destroy_devices(struct device *parent);
 int pci_pwrctrl_power_on_devices(struct device *parent);


### PR DESCRIPTION
…le or supply

The pci_pwrctrl_create_device() already guards against creating pwrctrl platform devices for DT nodes that lack a "compatible" property or have no power-supply defined. However, pci_pwrctrl_power_off_device() and pci_pwrctrl_power_on_device() do not apply the same checks, so they attempt to look up a platform device for every child node regardless of whether one was ever created.

Add the same two early-return guards to both power-on and power-off paths:

  1. Skip nodes that have no "compatible" property, since no platform device will have been registered for them.
  2. Skip nodes for which of_pci_supply_present() returns false, since pci_pwrctrl_create_device() would have skipped those nodes too.

This mirrors the logic already present in pci_pwrctrl_create_device() and avoids spurious of_find_device_by_node() lookups for nodes that were never registered as pwrctrl devices.

CRs-Fixed: 4507973