### PR TITLE
PENDING: arm64: dts: qcom: monaco-evk: fix overlay stacking and PHY reset polarity

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-staging.dtso
@@ -9,14 +9,16 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
-&eeprom1 {
-	nvmem-layout {
-		mac_addr1: mac-addr@0 {
-			reg = <0x0 0x6>;
-		};
+&i2c15 {
+	eeprom1: eeprom@52 {
+		nvmem-layout {
+			mac_addr1: mac-addr@0 {
+				reg = <0x0 0x6>;
+			};
 
-		mac_addr2: mac-addr@6 {
-			reg = <0x6 0x6>;
+			mac_addr2: mac-addr@6 {
+				reg = <0x6 0x6>;
+			};
 		};
 	};
 };
@@ -42,7 +44,7 @@
 				nvmem-cell-names = "mac-address";
 				pinctrl-names = "default";
 				pinctrl-0 = <&napa_intn_wol_sig>;
-				phy-reset-gpios = <&expander5 0 GPIO_ACTIVE_HIGH>;
+				phy-reset-gpios = <&expander5 0 GPIO_ACTIVE_LOW>;
 				reset-deassert-us = <20000>;
 			};
 		};


### PR DESCRIPTION
Fix issues with the Monaco EVK IFP Mezz staging overlay for QPS615:

1) Setting the VendorDtbOverlays EFI variable to "staging" causes UEFI
   to fail the overlay application entirely. The staging overlay
   references &eeprom1, a label introduced by the ifp-mezzanine
   overlay. When overlays are stacked, ufdt does not propagate
   __symbols__ from previously applied overlays into the working DTB,
   so &eeprom1 cannot be resolved as a fixup target and the firmware
   aborts with FDT_ERR_NOTFOUND. Fix this by defining the eeprom node
   inline under &i2c15, which is present in the base DTB __symbols__.

2) The QCA8081 port does not come out of reset and is therefore never
   detected. The PHY reset line is declared GPIO_ACTIVE_HIGH, but the
   QCA8081 has an active-low reset input. With GPIO_ACTIVE_HIGH the
   driver's deassert call maps logical 0 to physical LOW, holding
   RESETN asserted throughout probe. Correct it to GPIO_ACTIVE_LOW.

CRs-Fixed: 4510876