### PR TITLE
WORKAROUND: Disable L0s to fix wlan functionality

### DIFF
--- a/drivers/pci/controller/dwc/pcie-designware-host.c
+++ b/drivers/pci/controller/dwc/pcie-designware-host.c
@@ -1106,6 +1106,16 @@ int dw_pcie_setup_rc(struct dw_pcie_rp *pp)
 
 	dw_pcie_dbi_ro_wr_dis(pci);
 
+	/*
+	 * If iMSI-RX module is used as the MSI controller, remove MSI and
+	 * MSI-X capabilities from PCIe Root Ports to ensure fallback to INTx
+	 * interrupt handling.
+	 */
+	if (pp->has_msi_ctrl) {
+		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSI);
+		dw_pcie_remove_capability(pci, PCI_CAP_ID_MSIX);
+	}
+
 	return 0;
 }
 EXPORT_SYMBOL_GPL(dw_pcie_setup_rc);

--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -1483,6 +1483,7 @@ static const struct qcom_pcie_cfg cfg_1_9_0 = {
 static const struct qcom_pcie_cfg cfg_1_34_0 = {
 	.ops = &ops_1_9_0,
 	.override_no_snoop = true,
+	.no_l0s = true,
 };
 
 static const struct qcom_pcie_cfg cfg_2_1_0 = {


### PR DESCRIPTION
Enabling MSI on the Root Port triggers frequent AER errors and, in some cases,
SMMU faults on RB4 and RB8 platforms. The PCIe controller does not reliably
support MSI when using the Synopsys MSI implementation, and disabling MSI on
the Root Port exposed these AER issues.

A proper fix is under discussion with the SVE team. Until then, disable PCIe
L0s on RB4 and RB8 as a temporary workaround to stabilize the link and unblock
WLAN functionality for the RC3 release.
This change is a platform-specific mitigation and should be reverted once a
correct fix is available.

CRs-Fixed: 4489177