### PR TITLE
pci: pwrctrl: rename pci-pwrctrl-slot to generic

### DIFF
--- a/drivers/pci/controller/dwc/Kconfig
+++ b/drivers/pci/controller/dwc/Kconfig
@@ -299,7 +299,7 @@ config PCIE_QCOM
 	select CRC8
 	select PCIE_QCOM_COMMON
 	select PCI_HOST_COMMON
-	select PCI_PWRCTRL_SLOT
+	select PCI_PWRCTRL_GENERIC
 	help
 	  Say Y here to enable PCIe controller support on Qualcomm SoCs. The
 	  PCIe controller uses the DesignWare core plus Qualcomm-specific


### PR DESCRIPTION
Rename the remaining pci-pwrctrl-slot references to generic pwrctrl naming to align with CONFIG_PCI_PWRCTRL_GENERIC.

This fixes the build failure seen after enabling
CONFIG_PCI_PWRCTRL_GENERIC=y.