### PR TITLE
PENDING: arm64: dts: qcom: Add EL2 support for Iris for kodiak

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
@@ -27,7 +27,10 @@
 };
 
 &venus {
-	status = "disabled";
+	status = "okay";
+	video-firmware {
+		iommus = <&apps_smmu 0x21A2 0x0000>;
+	};
 };
 
 &watchdog {


### PR DESCRIPTION
Add support for IRIS on Kodiak when Linux host running at EL2.

Exception JIRA: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109

CRs-Fixed: 4345867