### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: enable EUD support

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -56,7 +56,7 @@
 				reg = <0>;
 
 				usb0_con_hs_ep: endpoint {
-					remote-endpoint = <&usb_0_dwc3_hs>;
+					remote-endpoint = <&eud_con>;
 				};
 			};
 			port@1 {
@@ -598,6 +598,14 @@
 	};
 };
 
+&eud_ep {
+	remote-endpoint = <&usb_0_dwc3_hs>;
+};
+
+&eud_con {
+	remote-endpoint = <&usb0_con_hs_ep>;
+};
+
 &gpi_dma0 {
 	status = "okay";
 };
@@ -1127,7 +1135,7 @@
 };
 
 &usb_0_dwc3_hs {
-	remote-endpoint = <&usb0_con_hs_ep>;
+	remote-endpoint = <&eud_ep>;
 };
 
 &usb_0_dwc3_ss {

--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -3978,6 +3978,32 @@
 			};
 		};
 
+		eud: eud@88e1000 {
+			compatible = "qcom,sc7280-eud", "qcom,eud";
+			reg = <0 0x88e1000 0 0x2000>,
+				<0 0x88e3000 0 0x1000>;
+			interrupts-extended = <&pdc 11 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+
+					eud_ep: endpoint {
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+
+					eud_con: endpoint {
+					};
+				};
+			};
+		};
+
 		usb_0_hsphy: phy@88e4000 {
 			compatible = "qcom,sa8775p-usb-hs-phy",
 				     "qcom,usb-snps-hs-5nm-phy";


### PR DESCRIPTION
Add the EUD controller node in lemans.dtsi and update the USB HS endpoint routing on lemans-evk to pass through EUD instead of linking the connector directly to usb_0_dwc3_hs.

Wire the OF graph endpoints between the connector, EUD and DWC3 HS controller to enable the EUD path on lemans EVK.

Link: https://lore.kernel.org/all/20260512091422.1395490-1-akash.kumar@oss.qualcomm.com/

CRs-Fixed: 4526711