### PR TITLE
QCLINUX: remoteproc: Panic on remoteproc crash

### DIFF
--- a/drivers/remoteproc/qcom_q6v5.c
+++ b/drivers/remoteproc/qcom_q6v5.c
@@ -107,6 +107,8 @@ static irqreturn_t q6v5_wdog_interrupt(int irq, void *data)
 		dev_err(q6v5->dev, "watchdog without message\n");
 
 	q6v5->running = false;
+	if (!(q6v5->rproc->dump_conf))
+		panic("SSR: Resetting the SoC.\n");
 	rproc_report_crash(q6v5->rproc, RPROC_WATCHDOG);
 
 	return IRQ_HANDLED;
@@ -128,6 +130,8 @@ static irqreturn_t q6v5_fatal_interrupt(int irq, void *data)
 		dev_err(q6v5->dev, "fatal error without message\n");
 
 	q6v5->running = false;
+	if (!(q6v5->rproc->dump_conf))
+		panic("SSR: Resetting the SoC.\n");
 	rproc_report_crash(q6v5->rproc, RPROC_FATAL_ERROR);
 
 	return IRQ_HANDLED;


### PR DESCRIPTION
Trigger a kernel panic on remoteproc crashes to collect full ramdump for debugging.