### PR TITLE
FROMLIST: arm64: dts: qcom: purwa: Add EL2 overlay for purwa-iot-evk

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -161,6 +161,10 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8998-sony-xperia-yoshino-maple.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8998-sony-xperia-yoshino-poplar.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8998-xiaomi-sagit.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= purwa-iot-evk.dtb
+
+purwa-iot-evk-el2-dtbs	:= purwa-iot-evk.dtb x1-el2.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= purwa-iot-evk-el2.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= qcm6490-fairphone-fp5.dtb
 
 dtb-$(CONFIG_ARCH_QCOM)	+= qcm6490-idp.dtb


### PR DESCRIPTION
Add support for building an EL2 combined DTB for the purwa-iot-evk in the Qualcomm DTS Makefile.

The new purwa-iot-evk-el2.dtb is generated by combining the base purwa-iot-evk.dtb with the x1-el2.dtbo overlay, enabling EL2-specific configurations required by the platform.

Reviewed-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>

Link: https://lore.kernel.org/all/20260417054200.2402281-1-xin.liu@oss.qualcomm.com/


CRs-Fixed: 4510094