### PR TITLE
PENDING: arm64: dts: qcom: lemans: remove GearVM reserved region to from iot memory map

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-auto.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-auto.dtsi
@@ -85,8 +85,18 @@
 			no-map;
 		};
 
+		firmware_mem: firmware-region@b0000000 {
+			reg = <0x0 0xb0000000 0x0 0x800000>;
+			no-map;
+		};
+
 		hyptz_reserved_mem: hyptz-reserved@beb00000 {
 			reg = <0x0 0xbeb00000 0x0 0x11500000>;
+			no-map;
+		};
+
+		scmi_mem: scmi-region@d0000000 {
+			reg = <0x0 0xd0000000 0x0 0x40000>;
 			no-map;
 		};
 

--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -982,16 +982,6 @@
 			no-map;
 		};
 
-		firmware_mem: firmware-region@b0000000 {
-			reg = <0x0 0xb0000000 0x0 0x800000>;
-			no-map;
-		};
-
-		scmi_mem: scmi-region@d0000000 {
-			reg = <0x0 0xd0000000 0x0 0x40000>;
-			no-map;
-		};
-
 		firmware_logs_mem: firmware-logs@d0040000 {
 			reg = <0x0 0xd0040000 0x0 0x10000>;
 			no-map;


### PR DESCRIPTION
This change is part of removing GearVM carveouts on both Lemans IOT and monaco. 
GearVM is currently not loaded or launched on QLI targets. 
lemans-auto still supports GearVM, we include in lemans-auto.dtsi.

CRs-Fixed: 4528975