### PR TITLE
QCLINUX: arm64: dts: qcom: add Purwa CAMX EL2 overlay

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -479,6 +479,10 @@ purwa-evk-camx-dtbs     := purwa-iot-evk.dtb purwa-evk-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM)	+= purwa-evk-camx.dtb
 
+purwa-camx-el2-dtbs     := purwa-iot-evk-el2.dtb purwa-evk-camx.dtbo purwa-camx-el2.dtbo
+
+dtb-$(CONFIG_ARCH_QCOM)	+= purwa-camx-el2.dtb
+
 qcs5430-fps-camx-dtbs   := qcs6490-rb3gen2.dtb qcs5430-fps-camx.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += qcs5430-fps-camx.dtb

--- a/arch/arm64/boot/dts/qcom/purwa-camx-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/purwa-camx-el2.dtso
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/soc@0/qcom,cam-icp";
+		__overlay__ {
+			camera-firmware {
+				iommus = <&apps_smmu 0x1901 0x0>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add a device tree overlay to enable EL2 boot support for the Purwa platform with CAMX configuration.

CRs-Fixed: 4546912