### PR TITLE
Revert "firmware: qcom: scm: Allow QSEECOM on Glymur CRD"

### DIFF
--- a/drivers/firmware/qcom/qcom_scm.c
+++ b/drivers/firmware/qcom/qcom_scm.c
@@ -2310,7 +2310,6 @@ static const struct of_device_id qcom_scm_qseecom_allowlist[] __maybe_unused = {
 	{ .compatible = "microsoft,denali", },
 	{ .compatible = "microsoft,romulus13", },
 	{ .compatible = "microsoft,romulus15", },
-	{ .compatible = "qcom,glymur-crd" },
 	{ .compatible = "qcom,hamoa-iot-evk" },
 	{ .compatible = "qcom,mahua-crd" },
 	{ .compatible = "qcom,purwa-iot-evk" },


### PR DESCRIPTION
Adding glymur-crd to the QSEECOM allowlist causes qcom_scm to fully initialize at early boot, which sets up uefisecapp and registers EFI variable operations. This makes efi_has_tpm2() succeed by reading the LoaderTpm2ActivePcrBanks EFI variable, satisfying ConditionSecurity=tpm2 in systemd.

As a result, systemd activates tpm2.target which unconditionally waits for /dev/tpm0 and /dev/tpmrm0.
systemd waits the full 90-second timeout for each of the two TPM device units, pushing total boot time beyond 2 minutes.

Revert until TPM driver in place and /dev/tpm0 node is created.

This reverts commit 87a1698cb80650e47b41ca78a78ce06870cba631.