### PR TITLE
net: stmmac: dwmac-qcom-ethqos: Restore nominal clk_ptp_ref frequency

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-qcom-ethqos.c
@@ -740,23 +740,6 @@ static void ethqos_clks_disable(void *data)
 	ethqos_clks_config(data, false);
 }
 
-static void ethqos_ptp_clk_freq_config(struct stmmac_priv *priv)
-{
-	struct plat_stmmacenet_data *plat_dat = priv->plat;
-	int err;
-
-	if (!plat_dat->clk_ptp_ref)
-		return;
-
-	/* Max the PTP ref clock out to get the best resolution possible */
-	err = clk_set_rate(plat_dat->clk_ptp_ref, ULONG_MAX);
-	if (err)
-		netdev_err(priv->dev, "Failed to max out clk_ptp_ref: %d\n", err);
-	plat_dat->clk_ptp_rate = clk_get_rate(plat_dat->clk_ptp_ref);
-
-	netdev_dbg(priv->dev, "PTP rate %lu\n", plat_dat->clk_ptp_rate);
-}
-
 static int qcom_ethqos_probe(struct platform_device *pdev)
 {
 	struct device_node *np = pdev->dev.of_node;
@@ -849,7 +832,6 @@ static int qcom_ethqos_probe(struct platform_device *pdev)
 	plat_dat->bsp_priv = ethqos;
 	plat_dat->fix_mac_speed = ethqos_fix_mac_speed;
 	plat_dat->dump_debug_regs = rgmii_dump;
-	plat_dat->ptp_clk_freq_config = ethqos_ptp_clk_freq_config;
 	plat_dat->core_type = DWMAC_CORE_GMAC4;
 	if (ethqos->has_emac_ge_3)
 		plat_dat->dwmac4_addrs = &data->dwmac4_addrs;


### PR DESCRIPTION
The current implementation configures the PTP reference clock (clk_ptp_ref) to its maximum supported frequency in order to improve timestamp resolution.

While higher clock rates benefit PTP/gPTP accuracy, forcing the PTP reference clock to operate at maximum frequency results in increased power consumption, as the clock remains at this rate irrespective of actual runtime requirements.

On power-sensitive platforms and in use cases where ultra-high timestamp precision is not required, this leads to unnecessary power overhead.

Update the driver to restore the nominal/default clock configuration for clk_ptp_ref, allowing the platform to operate at its baseline frequency (e.g., ~19.2 MHz). This reduces power consumption while maintaining functional correctness for standard PTP operation.

Higher clock frequencies can be enabled through targeted configuration if improved timestamp resolution is required for specific applications

CRs-Fixed: 4549777