### PR TITLE
QCLINUX: arm64: dts: qcom: Change Purwa camera firmware path

### DIFF
--- a/arch/arm64/boot/dts/qcom/purwa-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/purwa-camera.dtsi
@@ -34,7 +34,7 @@
 		src-clock-name = "icp_clk_src";
 		operating-points-v2 = <&icp_opp_table>;
 		clock-control-debugfs = "true";
-		fw_name = "qcom/x1p4x100/CAMERA_ICP";
+		fw_name = "qcom/x1p42100/CAMERA_ICP";
 		ubwc-ipe-fetch-cfg = <0x707b 0x7083>;
 		ubwc-ipe-write-cfg = <0x161ef 0x1620f>;
 		ubwc-bps-fetch-cfg = <0x707b 0x7083>;


### PR DESCRIPTION
Update the path for the camera icp firmware.

CRs-Fixed: 4555859