### PR TITLE
QCLINUX: arm64: dts: qcom: talos: Add GMSL deserializer and sensor

### DIFF
--- a/arch/arm64/boot/dts/qcom/talos-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/talos-camera-sensor.dtsi
@@ -142,6 +142,60 @@
 		cell-index = <1>;
 		status = "okay";
 	};
+
+	/* GMSL deserializer 0 - max9296a */
+	qcom,cam-gmsl-deserializer0 {
+		cell-index = <2>;
+		csiphy-sd-index = <1>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		cam_vio-supply = <&vreg_s4a>;
+		regulator-names = "cam_vio";
+		power-domains = <&camcc TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1800000>;
+		rgltr-max-voltage = <1800000>;
+		rgltr-load-current = <120000>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk2_active>;
+		pinctrl-1 = <&cam_sensor_mclk2_suspend>;
+		gpios = <&tlmm 29 0>;
+		gpio-reset = <0>;
+		gpio-req-tbl-num = <0>;
+		gpio-req-tbl-flags = <0>;
+		gpio-req-tbl-label = "CAM_RESET0";
+		cci-master = <1>;
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		status = "ok";
+
+		port@0 {
+			reg = <0>;
+			deser0_port0: endpoint {
+				remote-endpoint = <&gmsl_sensor0_ep>;
+			};
+		};
+	};
+
+	/* GMSL deserializer 0 sensor 0 */
+	qcom,cam-gmsl-sensor0 {
+		cell-index = <3>;
+		compatible = "qcom,cam-gmsl-sensor";
+
+		/* TBD */
+		csiphy-sd-index = <1>;
+		status = "ok";
+		port {
+			gmsl_sensor0_ep: endpoint {
+				remote-endpoint = <&deser0_port0>;
+			};
+		};
+	};
 };
 
 &soc {


### PR DESCRIPTION
Adds deserializer and camera sensor nodes to the Talos device tree. Talos features a single GMSL deserializer and exposes a single GMSL camera.

CRs-Fixed: 4549928