### PR TITLE
FROMLIST: PCI: qcom: Set max OPP before DBI access during resume

### DIFF
--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -1619,6 +1619,22 @@ static void qcom_pcie_icc_opp_update(struct qcom_pcie *pcie)
 	}
 }
 
+static int qcom_pcie_set_max_opp(struct device *dev)
+{
+	unsigned long max_freq = ULONG_MAX;
+	struct dev_pm_opp *opp;
+	int ret;
+
+	opp = dev_pm_opp_find_freq_floor(dev, &max_freq);
+	if (IS_ERR(opp))
+		return PTR_ERR(opp);
+
+	ret = dev_pm_opp_set_opp(dev, opp);
+	dev_pm_opp_put(opp);
+
+	return ret;
+}
+
 static int qcom_pcie_link_transition_count(struct seq_file *s, void *data)
 {
 	struct qcom_pcie *pcie = (struct qcom_pcie *)dev_get_drvdata(s->private);
@@ -1792,10 +1808,8 @@ static int qcom_pcie_parse_legacy_binding(struct qcom_pcie *pcie)
 static int qcom_pcie_probe(struct platform_device *pdev)
 {
 	const struct qcom_pcie_cfg *pcie_cfg;
-	unsigned long max_freq = ULONG_MAX;
 	struct qcom_pcie_port *port, *tmp;
 	struct device *dev = &pdev->dev;
-	struct dev_pm_opp *opp;
 	struct qcom_pcie *pcie;
 	struct dw_pcie_rp *pp;
 	struct resource *res;
@@ -1899,21 +1913,9 @@ static int qcom_pcie_probe(struct platform_device *pdev)
 	 * probe(), OPP will be updated using qcom_pcie_icc_opp_update().
 	 */
 	if (!ret) {
-		opp = dev_pm_opp_find_freq_floor(dev, &max_freq);
-		if (IS_ERR(opp)) {
-			ret = PTR_ERR(opp);
-			dev_err_probe(pci->dev, ret,
-				      "Unable to find max freq OPP\n");
-			goto err_pm_runtime_put;
-		} else {
-			ret = dev_pm_opp_set_opp(dev, opp);
-		}
-
-		dev_pm_opp_put(opp);
+		ret = qcom_pcie_set_max_opp(dev);
 		if (ret) {
-			dev_err_probe(pci->dev, ret,
-				      "Failed to set OPP for freq %lu\n",
-				      max_freq);
+			dev_err_probe(dev, ret, "Failed to set max OPP in probe\n");
 			goto err_pm_runtime_put;
 		}
 
@@ -2070,6 +2072,14 @@ static int qcom_pcie_resume_noirq(struct device *dev)
 			goto disable_icc_mem;
 	} else {
 		if (pm_suspend_target_state != PM_SUSPEND_MEM) {
+			if (pcie->use_pm_opp) {
+				ret = qcom_pcie_set_max_opp(dev);
+				if (ret) {
+					dev_err(dev, "Failed to set max OPP in resume: %d\n", ret);
+					return ret;
+				}
+			}
+
 			ret = icc_enable(pcie->icc_cpu);
 			if (ret) {
 				dev_err(dev, "Failed to enable CPU-PCIe interconnect path: %d\n",


### PR DESCRIPTION
During resume, qcom_pcie_icc_opp_update() may access DBI registers before the OPP votes are restored, which can trigger NoC errors.

Set the PCIe controller to the maximum OPP first in resume_noirq(), then proceed with link/DBI accesses. The OPP is later updated again based on the actual link bandwidth requirements.

Also introduce a small helper to reuse the max-OPP setup path shared with probe.

Fixes: 5b6272e0efd5 ("PCI: qcom: Add OPP support to scale performance")
Link: https://lore.kernel.org/all/20260416-setmaxopp-v1-1-6a74e2d945a0@oss.qualcomm.com/

CRs-Fixed: 4536367