### PR TITLE
QCLINUX: arm64: dts: qcom: monaco-evk: disable unused camera regulators

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-camx.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-camx.dtso
@@ -105,3 +105,15 @@
 		};
 	};
 };
+
+&vreg_cam0_2p8 {
+	status = "disabled";
+};
+
+&vreg_cam1_2p8 {
+	status = "disabled";
+};
+
+&vreg_cam2_2p8 {
+	status = "disabled";
+};


### PR DESCRIPTION
vreg_cam0_2p8, vreg_cam1_2p8 and vreg_cam2_2p8 are not used on the Monaco EVK board.

Disable them to prevent unintended regulator enablement.

CRs-Fixed: 4548865