### PR TITLE
WORKAROUND: power: sequencing: qcom-wcn: skip BT devices without bt-enable GPIO

### DIFF
--- a/drivers/power/sequencing/pwrseq-qcom-wcn.c
+++ b/drivers/power/sequencing/pwrseq-qcom-wcn.c
@@ -23,6 +23,7 @@ struct pwrseq_qcom_wcn_pdata {
 	unsigned int pwup_delay_ms;
 	unsigned int gpio_enable_delay_ms;
 	const struct pwrseq_target_data **targets;
+	bool bt_gpio_required; /* BT enable path requires a dedicated GPIO */
 };
 
 struct pwrseq_qcom_wcn_ctx {
@@ -309,6 +310,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn6855_of_data = {
 	.pwup_delay_ms = 50,
 	.gpio_enable_delay_ms = 5,
 	.targets = pwrseq_qcom_wcn6855_targets,
+	.bt_gpio_required = true,
 };
 
 static const char *const pwrseq_wcn7850_vregs[] = {
@@ -326,6 +328,7 @@ static const struct pwrseq_qcom_wcn_pdata pwrseq_wcn7850_of_data = {
 	.num_vregs = ARRAY_SIZE(pwrseq_wcn7850_vregs),
 	.pwup_delay_ms = 50,
 	.targets = pwrseq_qcom_wcn_targets,
+	.bt_gpio_required = true,
 };
 
 static int pwrseq_qcom_wcn_match(struct pwrseq_device *pwrseq,
@@ -358,17 +361,20 @@ static int pwrseq_qcom_wcn_match(struct pwrseq_device *pwrseq,
 		return PWRSEQ_NO_MATCH;
 
 	/*
-	 * If this is a Bluetooth consumer device but the bt-enable GPIO is not
-	 * configured in the power sequencer (e.g. BT_EN is tied high via a
-	 * hardware pull-up and therefore absent from the DT), don't match.
-	 * The consumer driver will fall back to its legacy power control path
-	 * and correctly set power_ctrl_enabled to false.
+	 * If this chip requires a dedicated BT enable GPIO (bt_gpio_required)
+	 * but the bt-enable GPIO is not configured in the power sequencer
+	 * (e.g. BT_EN is tied high via a hardware pull-up and therefore absent
+	 * from the DT), don't match.  The consumer driver will fall back to its
+	 * legacy power control path and correctly set power_ctrl_enabled to
+	 * false.  Chips like WCN3990 have no separate BT/WLAN enable pins by
+	 * design, so the flag is left unset for them and matching proceeds.
 	 *
 	 * BT device nodes are conventionally named "bluetooth" in the DT,
 	 * so use of_node_name_eq() as a generic check rather than enumerating
 	 * specific compatible strings.
 	 */
-	if (!ctx->bt_gpio && of_node_name_eq(dev_node, "bluetooth"))
+	if (ctx->pdata->bt_gpio_required && !ctx->bt_gpio &&
+	    of_node_name_eq(dev_node, "bluetooth"))
 		return PWRSEQ_NO_MATCH;
 
 	return PWRSEQ_MATCH_OK;


### PR DESCRIPTION
Add a bt_gpio_required flag to the per-platform data to indicate that a chip's BT enable path requires a dedicated GPIO.  Only skip matching the "bluetooth" device node when this flag is set and bt_gpio is absent.

Previously the bt_gpio check was applied unconditionally, which caused chips like WCN3990 that have no separate BT/WLAN enable pins by design to fail matching even when bt-enable GPIO is legitimately absent from the DT.  Set bt_gpio_required for WCN6855 and WCN7850 which do require a dedicated BT enable GPIO.

The qcom-6.18.y branch also needs to fix this issue.
Fix-issues:  https://github.com/qualcomm-linux/kernel/issues/625
depend on: https://github.com/qualcomm-linux/kernel/pull/760
CRs-Fixed: 4602678