### PR TITLE
Drop IPA interconnect and model it as clock resource

### DIFF
--- a/Documentation/devicetree/bindings/interconnect/qcom,qcs615-rpmh.yaml
+++ b/Documentation/devicetree/bindings/interconnect/qcom,qcs615-rpmh.yaml
@@ -27,7 +27,6 @@ properties:
       - qcom,qcs615-config-noc
       - qcom,qcs615-dc-noc
       - qcom,qcs615-gem-noc
-      - qcom,qcs615-ipa-virt
       - qcom,qcs615-mc-virt
       - qcom,qcs615-mmss-noc
       - qcom,qcs615-system-noc
@@ -46,7 +45,6 @@ allOf:
           contains:
             enum:
               - qcom,qcs615-camnoc-virt
-              - qcom,qcs615-ipa-virt
               - qcom,qcs615-mc-virt
     then:
       properties:

--- a/arch/arm64/boot/dts/qcom/talos.dtsi
+++ b/arch/arm64/boot/dts/qcom/talos.dtsi
@@ -482,12 +482,6 @@
 		qcom,bcm-voters = <&apps_bcm_voter>;
 	};
 
-	ipa_virt: interconnect-1 {
-		compatible = "qcom,qcs615-ipa-virt";
-		#interconnect-cells = <2>;
-		qcom,bcm-voters = <&apps_bcm_voter>;
-	};
-
 	mc_virt: interconnect-2 {
 		compatible = "qcom,qcs615-mc-virt";
 		#interconnect-cells = <2>;

--- a/drivers/clk/qcom/clk-rpmh.c
+++ b/drivers/clk/qcom/clk-rpmh.c
@@ -868,6 +868,7 @@ static struct clk_hw *qcs615_rpmh_clocks[] = {
 	[RPMH_RF_CLK1_A]	= &clk_rpmh_rf_clk1_a_ao.hw,
 	[RPMH_RF_CLK2]		= &clk_rpmh_rf_clk2_a.hw,
 	[RPMH_RF_CLK2_A]	= &clk_rpmh_rf_clk2_a_ao.hw,
+	[RPMH_IPA_CLK]		= &clk_rpmh_ipa.hw,
 };
 
 static const struct clk_rpmh_desc clk_rpmh_qcs615 = {


### PR DESCRIPTION
Bring the IP0 resource from ICC to clk-rpmh on Talos(qcs615)
qli-2.0 GA Critical Fix

CRs-Fixed: 4563868
Link: https://lore.kernel.org/all/20250627-topic-qcs615_icc_ipa-v1-0-dc47596cde69@oss.qualcomm.com/