### PR TITLE
shikra: Enable GPU (dt bindings + driver support)

### DIFF
--- a/Documentation/devicetree/bindings/display/msm/gpu.yaml
+++ b/Documentation/devicetree/bindings/display/msm/gpu.yaml
@@ -358,6 +358,7 @@ allOf:
               - qcom,adreno-610.0
               - qcom,adreno-619.1
               - qcom,adreno-07000200
+              - qcom,adreno-07000400
     then:
       properties:
         clocks:

--- a/Documentation/devicetree/bindings/iommu/arm,smmu.yaml
+++ b/Documentation/devicetree/bindings/iommu/arm,smmu.yaml
@@ -547,6 +547,7 @@ allOf:
             - enum:
                 - qcom,milos-smmu-500
                 - qcom,sar2130p-smmu-500
+                - qcom,shikra-smmu-500
                 - qcom,sm8550-smmu-500
                 - qcom,sm8650-smmu-500
                 - qcom,x1e80100-smmu-500

--- a/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
+++ b/drivers/gpu/drm/msm/adreno/a6xx_catalog.c
@@ -1433,7 +1433,7 @@ DECLARE_ADRENO_REGLIST_LIST(a750_ifpc_reglist);
 
 static const struct adreno_info a7xx_gpus[] = {
 	{
-		.chip_ids = ADRENO_CHIP_IDS(0x07000200),
+		.chip_ids = ADRENO_CHIP_IDS(0x07000200, 0x07000400),
 		.family = ADRENO_6XX_GEN1, /* NOT a mistake! */
 		.fw = {
 			[ADRENO_FW_SQE] = "a702_sqe.fw",


### PR DESCRIPTION
Add support for the Shikra Adreno A704 GPU in the Linux kernel by extending the existing A702-based MSM Adreno support. The change adds the A704 DT compatible and chip ID so the DRM/MSM driver can recognize and initialize the GPU using the shared A702 configuration.  Also adds binding documentation for the Shikra Adreno SMMU instance, including the required clock configuration.

qli-2.0 GA Critical Fix

CRs-Fixed: 4569893
