### PR TITLE
arm64: dts: qcom: monaco-evk-emmc: Remove explicit UFS disablement

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco-evk-emmc.dtso
+++ b/arch/arm64/boot/dts/qcom/monaco-evk-emmc.dtso
@@ -35,12 +35,3 @@
 
 	status = "okay";
 };
-
-&ufs_mem_hc {
-	status = "disabled";
-};
-
-&vreg_l8a {
-	regulator-min-microvolt = <2960000>;
-	regulator-max-microvolt = <2960000>;
-};


### PR DESCRIPTION
The eMMC overlay currently explicitly disables the UFS host controller and overrides the vreg_l8a voltage. This causes unnecessary UFS disablement in scenarios where UFS is the boot medium and eMMC is used as secondary storage.

Since UFS and eMMC share a common VDD rail, their mutual exclusivity is now managed dynamically via DT-fixup logic. Remove these static entries from the overlay to allow flexible storage configurations.

CRs-Fixed: 4569877