### PR TITLE
WORKAROUND: Move CPU PM notifier registration to Probe

### DIFF
--- a/drivers/ras/aest/aest-core.c
+++ b/drivers/ras/aest/aest-core.c
@@ -1166,6 +1166,8 @@ static int aest_device_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, adev);
 
+	aest_cpu_pm_init();
+
 	aest_dev_init_debugfs(adev);
 
 	aest_dev_dbg(adev, "Node cnt: %x, id: %x\n", adev->node_cnt, adev->id);
@@ -1186,9 +1188,6 @@ static int __init aest_init(void)
 #ifdef CONFIG_DEBUG_FS
 	aest_debugfs = debugfs_create_dir("aest", NULL);
 #endif
-
-	aest_cpu_pm_init();
-
 	return platform_driver_register(&aest_driver);
 }
 module_init(aest_init);


### PR DESCRIPTION
Fix issue of CPU PM notifier being registered for targets on which this feature is not enabled by moving it to probe instead of registering it from module_init.

CRs-Fixed: 4570835