### PR TITLE
WORKAROUND: arm64: dts: qcom: Add qref and refgen supplies for Lemans PCIe PHYs

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans-evk.dts
+++ b/arch/arm64/boot/dts/qcom/lemans-evk.dts
@@ -845,6 +845,8 @@
 &pcie0_phy {
 	vdda-phy-supply = <&vreg_l5a>;
 	vdda-pll-supply = <&vreg_l1c>;
+	vdda-qref-supply = <&vreg_l4a>;
+	vdda-refgen-supply = <&vreg_l7a>;
 
 	status = "okay";
 };
@@ -862,6 +864,8 @@
 &pcie1_phy {
 	vdda-phy-supply = <&vreg_l5a>;
 	vdda-pll-supply = <&vreg_l1c>;
+	vdda-qref-supply = <&vreg_l4a>;
+	vdda-refgen-supply = <&vreg_l7a>;
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/lemans-ride-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans-ride-common.dtsi
@@ -990,6 +990,8 @@
 &pcie0_phy {
 	vdda-phy-supply = <&vreg_l5a>;
 	vdda-pll-supply = <&vreg_l1c>;
+	vdda-qref-supply = <&vreg_l4a>;
+	vdda-refgen-supply = <&vreg_l7a>;
 
 	status = "okay";
 };
@@ -997,6 +999,8 @@
 &pcie1_phy {
 	vdda-phy-supply = <&vreg_l5a>;
 	vdda-pll-supply = <&vreg_l1c>;
+	vdda-qref-supply = <&vreg_l4a>;
+	vdda-refgen-supply = <&vreg_l7a>;
 
 	status = "okay";
 };


### PR DESCRIPTION
All PCIe PHYs on Lemans require vdda-qref and vdda-refgen power supplies, but these are missing in the current PHY device tree nodes. The PCIe port can still function because the regulators are voted by other components.

Since the device tree should accurately describe the hardware, add the vdda-qref and vdda-refgen power supplies explicitly in all PCIe PHY device nodes for lemans-evk and lemans-ride-common.

Workaround will be reverted once the vote qref regulator for PCIe available in upstream.

Signed-off-by: Ziyue Zhang <ziyue.zhang@oss.qualcomm.com>
CRs-Fixed: 4537722