### PR TITLE
Revert "FROMLIST: arm64: dts: qcom: monaco: fix wrong connection for the replicator"

### DIFF
--- a/arch/arm64/boot/dts/qcom/monaco.dtsi
+++ b/arch/arm64/boot/dts/qcom/monaco.dtsi
@@ -2935,14 +2935,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				port@0 {
-					reg = <0>;
-
-					swao_rep_out0: endpoint {
-						remote-endpoint = <&qdss_rep_in>;
-					};
-				};
-
 				port@1 {
 					reg = <1>;
 
@@ -3651,6 +3643,14 @@
 			out-ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+
+					swao_rep_out0: endpoint {
+						remote-endpoint = <&qdss_rep_in>;
+					};
+				};
 
 				port@1 {
 					reg = <1>;


### PR DESCRIPTION
This reverts commit 99beb1dbcb3dee954e5d1c3984ee373fe95140ea. This is a corrective patch for a mistake that causes an ETR connection issue; it needs to be reverted. This patch aims to fix a mistake issue made by maintainer on upstream, but the issue does not exist on qli2.0.

 CRs-Fixed: 4571415