### PR TITLE
PENDING: arm64: dts: enable iris driver for hamoa kvm

### DIFF
--- a/arch/arm64/boot/dts/qcom/x1-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/x1-el2.dtso
@@ -17,8 +17,10 @@
 };
 
 &iris {
-	/* TODO: Add video-firmware iommus to start IRIS from EL2 */
-	status = "disabled";
+	status = "okay";
+	video-firmware {
+		iommus = <&apps_smmu 0x1942 0x0>;
+	};
 };
 
 /*


### PR DESCRIPTION
Add video firmware node to enable video kvm on the hamoa.

The community recommends implementing KVM support using the iommu-map approach. However, the device creation model based on iris_vpu_bus is still under discussion.
Temporarily keep using the video-firmware node approach in the Iris driver to enable KVM support. This change is intended as a stopgap.
Once the community patches are merged, or the iris_vpu_bus-based device creation is finalized, this will be reverted and replaced with the community-recommended approach.

https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-109
CRs-Fixed: 4559873