### PR TITLE
QCLINUX: arm64: dts: qcom: Add Hamoa camera sensor support

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa-camera-sensor.dtsi
@@ -18,8 +18,8 @@
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
 		rgltr-cntrl-support;
 		pwm-switch;
-		rgltr-min-voltage = <1800000>;
-		rgltr-max-voltage = <1800000>;
+		rgltr-min-voltage = <1808000>;
+		rgltr-max-voltage = <1808000>;
 		rgltr-load-current = <120000>;
 		gpio-no-mux = <0>;
 		pinctrl-names = "cam_default", "cam_suspend";
@@ -41,6 +41,79 @@
 		clock-cntl-level = "nominal";
 		clock-rates = <24000000>;
 		cell-index = <0>;
+		status = "okay";
+	};
+
+	/*cam1-og0a1b*/
+	qcom,cam-sensor1 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <0>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		cam_vio-supply = <&vreg_l4m_1p8>;
+		cam_vana-supply = <&vreg_l7m_2p9>;
+		regulator-names = "cam_vio", "cam_vana";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1808000 2912000>;
+		rgltr-max-voltage = <1808000 2912000>;
+		rgltr-load-current = <120000 120000>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_active &cam_sensor_active_rst0>;
+		pinctrl-1 = <&cam_sensor_mclk0_suspend &cam_sensor_suspend_rst0>;
+		gpios = <&tlmm 96 0>, <&tlmm 109 0>;
+		gpio-reset = <1>;
+		gpio-req-tbl-num = <0 1>;
+		gpio-req-tbl-flags = <1 0>;
+		gpio-req-tbl-label = "CAM_MCLK0", "CAMIF_RESET0";
+		cci-master = <0>;
+		clocks = <&camcc CAM_CC_MCLK0_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <1>;
+		status = "okay";
+	};
+};
+
+&cam_cci1 {
+	/*cam2-imx688*/
+	qcom,cam-sensor4 {
+		compatible = "qcom,cam-sensor";
+		csiphy-sd-index = <4>;
+		sensor-position-roll = <0>;
+		sensor-position-pitch = <0>;
+		sensor-position-yaw = <180>;
+		cam_vio-supply = <&vreg_l4m_1p8>;
+		cam_vana-supply = <&vreg_l6m_1p8>;
+		cam_vdig-supply = <&vreg_l1m_1p1>;
+		cam_v_custom1-supply = <&vreg_l7b_2p8>;
+		regulator-names = "cam_vio", "cam_vana", "cam_vdig", "cam_v_custom1";
+		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
+		rgltr-cntrl-support;
+		pwm-switch;
+		rgltr-min-voltage = <1808000 1808000 1056000 2800000>;
+		rgltr-max-voltage = <1808000 1808000 1200000 2800000>;
+		rgltr-load-current = <120000 120000 120000 120000>;
+		gpio-no-mux = <0>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk4_active &cam_sensor_active_rst4>;
+		pinctrl-1 = <&cam_sensor_mclk4_suspend &cam_sensor_suspend_rst4>;
+		gpios = <&tlmm 100 0>, <&tlmm 237 0>, <&tlmm 233 0>;
+		gpio-reset = <1>;
+		gpio-custom1 = <2>;
+		gpio-req-tbl-num = <0 1 2>;
+		gpio-req-tbl-flags = <1 0 0>;
+		gpio-req-tbl-label = "CAM_MCLK4", "CAMIF_RESET4", "CAM_CUSTOM1";
+		cci-master = <1>;
+		clocks = <&camcc CAM_CC_MCLK4_CLK>;
+		clock-names = "cam_clk";
+		clock-cntl-level = "nominal";
+		clock-rates = <24000000>;
+		cell-index = <4>;
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Add og0a1b VGA camera sensor node (cam-sensor1) on CCI0 and
imx688 camera sensor node (cam-sensor4) on CCI1 for Hamoa board.

og0a1b (cam-sensor1):
- MCLK0 / CCI master 0
- 1.8V IO supply (vreg_l4m_1p8), 2.9V analog supply (vreg_l7m_2p9)
- GPIO reset: TLMM 109, MCLK: TLMM 96
- Sensor position: yaw=180 (rear-facing)

imx688 (cam-sensor4):
- MCLK4 / CCI1 master 1
- 1.8V IO supply (vreg_l4m_1p8), 1.8V analog supply (vreg_l6m_1p8)
- 1.056V digital supply (vreg_l1m_1p1), 2.8V custom supply (vreg_l7b_2p8)
- GPIO reset: TLMM 237, MCLK: TLMM 100, custom GPIO: TLMM 233
- Sensor position: yaw=180 (rear-facing)

CRs-Fixed: 4561668
Signed-off-by: shubamm <shubamm@qti.qualcomm.com>