### PR TITLE
media: qcom: iris: fix enum_frameintervals to support non-integer framerates

### DIFF
--- a/drivers/media/platform/qcom/iris/iris_vidc.c
+++ b/drivers/media/platform/qcom/iris/iris_vidc.c
@@ -442,10 +442,10 @@ static int iris_enum_frameintervals(struct file *filp, void *fh,
 
 	fival->type = V4L2_FRMIVAL_TYPE_STEPWISE;
 	fival->stepwise.min.numerator = 1;
-	fival->stepwise.min.denominator =
-			min_t(u32, fps, MAXIMUM_FPS);
+	fival->stepwise.min.denominator = 1;
 	fival->stepwise.max.numerator = 1;
-	fival->stepwise.max.denominator = 1;
+	fival->stepwise.max.denominator =
+			min_t(u32, fps, MAXIMUM_FPS);
 	fival->stepwise.step.numerator = 1;
 	fival->stepwise.step.denominator = MAXIMUM_FPS;
 


### PR DESCRIPTION
Encoding fails with "internal data stream error" for input videos with
non-integer framerates (e.g., 29.97 fps / 30000/1001) 
video driver returned a STEPWISE range with min=1/fps and max=1/1.
GStreamer enumerated this as a discrete list of framerates (480/1,
240/1, ..., 30/1, ..., 1/1). Since 29.97 fps is not expressible as 480/n for
any integer n, caps negotiation failed.

Swap min and max denominators (min=1/1, max=1/fps). GStreamer's
loop condition fails immediately, no discrete list is built, and the
framerate is left unconstrained, accepting any framerate including
29.97 fps. 

CRs-Fixed: 4515234