### PR TITLE
QCLINUX: arm64: dts: qcom: Add shared X1 staging overlay

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -547,4 +547,6 @@ dtb-$(CONFIG_ARCH_QCOM) += kodiak-staging.dtbo
 
 dtb-$(CONFIG_ARCH_QCOM) += hamoa-staging.dtbo
 
+dtb-$(CONFIG_ARCH_QCOM) += purwa-staging.dtbo
+
 dtb-$(CONFIG_ARCH_QCOM)	+= glymur-staging.dtbo

--- a/arch/arm64/boot/dts/qcom/purwa-staging.dtso
+++ b/arch/arm64/boot/dts/qcom/purwa-staging.dtso
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
- * Hamoa staging overlay - add staging-specific device tree modifications here.
+ * Purwa staging overlay - add staging-specific device tree modifications here.
  */
 
 /dts-v1/;

--- a/arch/arm64/boot/dts/qcom/x1-staging.dtsi
+++ b/arch/arm64/boot/dts/qcom/x1-staging.dtsi
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * Shared X1 staging device tree modifications.
+ */
+
+#include <dt-bindings/thermal/thermal.h>
+
+&soc {
+	tgu@10b0e000 {
+		compatible = "qcom,tgu", "arm,primecell";
+		reg = <0x0 0x10b0e000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+	};
+
+	tgu@10b0f000 {
+		compatible = "qcom,tgu", "arm,primecell";
+		reg = <0x0 0x10b0f000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+	};
+
+	tgu@10b10000 {
+		compatible = "qcom,tgu", "arm,primecell";
+		reg = <0x0 0x10b10000 0x0 0x1000>;
+
+		clocks = <&aoss_qmp>;
+		clock-names = "apb_pclk";
+	};
+};
+
+&remoteproc_cdsp {
+	cooling {
+		compatible = "qcom,qmi-cooling-cdsp";
+
+		cdsp_tmd0: cdsp-tmd0 {
+			label = "cdsp_sw";
+			#cooling-cells = <2>;
+		};
+	};
+};
+
+&thermal_nsp0 {
+	trips {
+		nsp0_alert0: trip-point1 {
+			temperature = <105000>;
+			hysteresis = <5000>;
+			type = "passive";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&nsp0_alert0>;
+			cooling-device = <&cdsp_tmd0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&thermal_nsp1 {
+	trips {
+		nsp1_alert0: trip-point1 {
+			temperature = <105000>;
+			hysteresis = <5000>;
+			type = "passive";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&nsp1_alert0>;
+			cooling-device = <&cdsp_tmd0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&thermal_nsp2 {
+	trips {
+		nsp2_alert0: trip-point1 {
+			temperature = <105000>;
+			hysteresis = <5000>;
+			type = "passive";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&nsp2_alert0>;
+			cooling-device = <&cdsp_tmd0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&thermal_nsp3 {
+	trips {
+		nsp3_alert0: trip-point1 {
+			temperature = <105000>;
+			hysteresis = <5000>;
+			type = "passive";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&nsp3_alert0>;
+			cooling-device = <&cdsp_tmd0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};


### PR DESCRIPTION
Move the common Hamoa staging overlay contents into x1-staging.dtsi so they can be shared across X1 platforms. Keep hamoa-staging.dtso as a thin wrapper around the shared include and add purwa-staging.dtso to build an identical staging overlay for Purwa.

CRs-Fixed: 4576294