### PR TITLE
PENDING: arm64: dts: qcom: shikra: add reboot-mode support

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra-evk.dtsi
@@ -9,6 +9,13 @@
 	status = "okay";
 };
 
+&psci {
+	reboot-mode {
+		mode-bootloader = <0x10001 0x2>;
+		mode-edl = <0 0x1>;
+	};
+};
+
 &qupv3_0 {
 	firmware-name = "qcom/shikra/qupv3fw.elf";
 	status = "okay";

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -259,7 +259,7 @@
 		interrupts = <GIC_PPI 5 IRQ_TYPE_LEVEL_HIGH &ppi_cluster1>;
 	};
 
-	psci {
+	psci: psci {
 		compatible = "arm,psci-1.0";
 		method = "smc";
 	};


### PR DESCRIPTION
Add reboot-mode child nodes to shikra-evk.dtsi to configure fastboot (mode-bootloader) and EDL (mode-edl) reboot modes, since all EVK board DTS files include this shared DTSI.


CRs-Fixed: 4576889
QLI JIRA Exception: https://jira-dc.qualcomm.com/jira/browse/QLIJIRA-139