### PR TITLE
arm64: dts: qcom: kodiak-el2: remove wpss iommus, add wifi-firmware i…

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
@@ -5,7 +5,6 @@
  * Kodiak specific modifications required to boot in EL2.
  */
 
-
 /dts-v1/;
 /plugin/;
 
@@ -21,9 +20,14 @@
 	iommus = <&apps_smmu 0x11a0 0x0400>;
 };
 
-&remoteproc_wpss {
-	iommus = <&apps_smmu 0x1c03 0x1>,
-		 <&apps_smmu 0x1c83 0x1>;
+&reserved_memory {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	wlan_ce_mem: wlan-ce@4cd000 {
+		no-map;
+		reg = <0x0 0x004cd000 0x0 0x1000>;
+	};
 };
 
 &venus {
@@ -35,4 +39,13 @@
 
 &watchdog {
 	status = "okay";
+};
+
+&wifi {
+	memory-region = <&wlan_fw_mem>, <&wlan_ce_mem>;
+	status = "okay";
+
+	wifi-firmware {
+		iommus = <&apps_smmu 0x1c02 0x1>;
+	};
 };

--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
+++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
@@ -91,7 +91,7 @@
 		};
 	};
 
-	reserved-memory {
+	reserved_memory: reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;


### PR DESCRIPTION
…ommus

The WPSS does not have dedicated firmware IOMMU context banks that Linux needs to manage. The SIDs in the WPSS range are in fact used for WCN6750 Wi-Fi firmware DMA operations (MSA firmware region and Copy Engine region) once Wi-Fi is brought up. The ath11k driver looks for a "wifi-firmware" child node under the Wi-Fi device and creates a dedicated platform device to map these firmware DMA regions through the IOMMU. This matches the pattern established in sc7280-chrome-common.dtsi where iommus are declared on the wifi-firmware child node under &wifi, not on remoteproc_wpss itself.

Remove iommu entries for wpss from kodiak-el2 overlay file.

CRs-Fixed: 4583945