### PR TITLE
PENDING: arm64: dts: qcom: shikra: fix ethernet interrupt specifier cell count

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -2931,7 +2931,7 @@
 			      <0x0 0x05d16000 0x0 0x100>;
 			reg-names = "stmmaceth", "rgmii";
 
-			interrupts = <GIC_SPI 478 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 478 IRQ_TYPE_LEVEL_HIGH 0>;
 			interrupt-names = "macirq";
 
 			clocks = <&gcc GCC_EMAC0_AXI_CLK>,
@@ -2970,7 +2970,7 @@
 			      <0x0 0x05d36000 0x0 0x100>;
 			reg-names = "stmmaceth", "rgmii";
 
-			interrupts = <GIC_SPI 458 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 458 IRQ_TYPE_LEVEL_HIGH 0>;
 			interrupt-names = "macirq";
 
 			clocks = <&gcc GCC_EMAC1_AXI_CLK>,


### PR DESCRIPTION
Commit bf449f3bcc81 ("arm64: dts: qcom: shikra: switch to interrupt-cells 4 to add PPI partitions") bumped the GIC node to interrupt-cells = <4> and updated all existing interrupt specifiers accordingly. The ethernet nodes, raised on top of the older version of the patch series are left with a 3-cell specifier against a 4-cell GIC.

At boot, of_irq_parse_one() reads intsize=4 from the GIC, then of_property_read_u32_index() attempts to read the 4th cell of a 3-cell property and returns -EOVERFLOW, causing
platform_get_irq_byname("macirq") to fail with -ENXIO:

  qcom-ethqos 5d00000.ethernet: error -ENXIO: IRQ macirq not found
  qcom-ethqos 5d00000.ethernet: error -ENXIO: Failed to get platform
resources

Add the missing 4th cell to both ethernet nodes. **This will be posted in V2 of the ethernet series.
The QLI mainline PR has been updated with the fix (https://github.com/qualcomm-linux/kernel-topics/pull/1318).
Using PENDING tag for this branch as its a minor change which will be included in the next iteration of the series.**

Fixes: a1b735d91845 ("arm64: dts: qcom: shikra: Add ethernet nodes")
CRs-Fixed: 4570559