### PR TITLE
Fix probe failure on Shikra IQS board

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -539,8 +539,8 @@
 
 	ethernet1_defaults: ethernet1-defaults-state {
 		rgmii-rx-pins {
-			pins = "gpio137", "gpio138", "gpio139",
-			       "gpio140", "gpio141", "gpio142";
+			pins = "gpio137", "gpio139", "gpio140",
+			       "gpio141", "gpio142";
 			function = "rgmii";
 			bias-disable;
 			drive-strength = <16>;

--- a/arch/arm64/configs/prune.config
+++ b/arch/arm64/configs/prune.config
@@ -93,7 +93,6 @@
 # CONFIG_BCM54140_PHY is not set
 # CONFIG_MICROSEMI_PHY is not set
 # CONFIG_ROCKCHIP_PHY is not set
-# CONFIG_DP83867_PHY is not set
 # CONFIG_DP83TD510_PHY is not set
 # CONFIG_VITESSE_PHY is not set
 # CONFIG_CAN_FLEXCAN is not set


### PR DESCRIPTION
GPIO138 is a reserved GPIO, with its access protected by TZ. Remove it from ethernet1_default_state so that its probe doesn't fail due to Kernel access to GPIO138 being restricted. Also enable the TI PHY config (by removing it from prune.config) so that the ethernet interface is brought up properly with the DP83867 driver instead of the generic PHY driver.
