### PR TITLE
FROMLIST: ASoC: qcom: q6apm-dai: fix carveout buffer sizing and SCM assignment

### DIFF
--- a/sound/soc/qcom/qdsp6/q6apm-dai.c
+++ b/sound/soc/qcom/qdsp6/q6apm-dai.c
@@ -152,7 +152,7 @@ static int q6apm_dai_assign_memory(struct snd_pcm_substream *substream,
 	}
 
 	scm_region->dma_addr = substream->dma_buffer.addr;
-	scm_region->size = ALIGN(BUFFER_BYTES_MAX, PAGE_SIZE);
+	scm_region->size = ALIGN(pdata->reserved_buf_size, PAGE_SIZE);
 	scm_region->src_perms = BIT_ULL(QCOM_SCM_VMID_HLOS);
 
 	ret = qcom_scm_assign_mem(scm_region->dma_addr, scm_region->size,
@@ -588,7 +588,9 @@ static int q6apm_dai_open(struct snd_soc_component *component,
 
 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK) {
 		ret = snd_pcm_hw_constraint_minmax(runtime, SNDRV_PCM_HW_PARAM_BUFFER_BYTES,
-						   BUFFER_BYTES_MIN, BUFFER_BYTES_MAX);
+						   BUFFER_BYTES_MIN,
+						   pdata->has_reserved_mem ?
+						   pdata->reserved_buf_size : BUFFER_BYTES_MAX);
 		if (ret < 0) {
 			dev_err(dev, "constraint for buffer bytes min max ret = %d\n", ret);
 			goto err;
@@ -609,7 +611,8 @@ static int q6apm_dai_open(struct snd_soc_component *component,
 	}
 
 	runtime->private_data = prtd;
-	runtime->dma_bytes = BUFFER_BYTES_MAX;
+	runtime->dma_bytes = pdata->has_reserved_mem ?
+			pdata->reserved_buf_size : BUFFER_BYTES_MAX;
 	if (pdata->sid < 0)
 		prtd->phys = substream->dma_buffer.addr;
 	else
@@ -701,7 +704,7 @@ static int q6apm_dai_memory_map(struct snd_soc_component *component,
 	else
 		phys = substream->dma_buffer.addr | (pdata->sid << 32);
 
-	ret = q6apm_map_memory_fixed_region(dev, graph_id, phys, BUFFER_BYTES_MAX);
+	ret = q6apm_map_memory_fixed_region(dev, graph_id, phys, pdata->reserved_buf_size);
 	if (ret < 0)
 		dev_err(dev, "Audio Start: Buffer Allocation failed rc = %d\n", ret);
 
@@ -728,10 +731,9 @@ static int q6apm_dai_pcm_new(struct snd_soc_component *component, struct snd_soc
 	 * Fall back to the standard fixed system-RAM buffer on other platforms.
 	 */
 	if (pdata->has_reserved_mem)
-		ret = snd_pcm_set_managed_buffer_all(pcm, SNDRV_DMA_TYPE_DEV,
-						     component->dev,
-						     pdata->reserved_buf_size,
-						     pdata->reserved_buf_size);
+		ret = snd_pcm_set_fixed_buffer_all(pcm, SNDRV_DMA_TYPE_DEV,
+						   component->dev,
+						   pdata->reserved_buf_size);
 	else
 		ret = snd_pcm_set_fixed_buffer_all(pcm, SNDRV_DMA_TYPE_DEV,
 						   component->dev, size);
@@ -1289,7 +1291,7 @@ static int q6apm_dai_probe(struct platform_device *pdev)
 						      dev);
 			if (rc)
 				return rc;
-			pdata->reserved_buf_size = min_t(size_t, rmem->size,
+			pdata->reserved_buf_size = min_t(size_t, rmem->size / 4,
 							 BUFFER_BYTES_MAX);
 			pdata->has_reserved_mem = true;
 		} else {
@@ -1306,6 +1308,20 @@ static int q6apm_dai_probe(struct platform_device *pdev)
 						    idx++))) {
 			struct reserved_mem *rmem;
 			struct q6apm_scm_region *r;
+
+			/*
+			 * Only index 0 (control-path carveout) is
+			 * SCM-assigned via carveout_regions[]. Index 1+
+			 * are data-path DMA pools handled per-substream
+			 * by q6apm_dai_assign_memory() in pcm_new().
+			 * Including them here causes a double-assignment
+			 * of the same physical region which TZ rejects
+			 * with -EINVAL.
+			 */
+			if (idx > 1) {
+				of_node_put(mem_node);
+				break;
+			}
 
 			if (pdata->num_carveouts >= Q6APM_MAX_CARVEOUTS) {
 				dev_warn(dev,


### PR DESCRIPTION
FROMLIST: ASoC: qcom: q6apm-dai: fix carveout buffer sizing and SCM assignment

cap reserved_buf_size at rmem->size / 4 so the 1 MB carveout is
divided into four equal 256 KB slots, fitting up to 4 substreams.
Align the SCM window size, DSP memory map size, hw_params ceiling,
and runtime->dma_bytes to reserved_buf_size so all layers see a
consistent per-substream window. Switch to snd_pcm_set_fixed_buffer_all
(max=0) to lock the buffer address so hw_params cannot reallocate at a
different physical address after the DSP map and SCM assignment
have been committed.

Note: This PR represents a subset of the upstream changes and includes
the required fix.

Link: https://lore.kernel.org/all/20260624123748.502781-1-ajay.nandam@oss.qualcomm.com/
Signed-off-by: Ajay Kumar Nandam <ajay.nandam@oss.qualcomm.com>

CRs-Fixed: 4583905
qli-2.0 GA Critical Fix
