### PR TITLE
PENDING: drm/msm/dp: disable HPD IRQ during shutdown to prevent IOMMU

### DIFF
--- a/drivers/gpu/drm/msm/dp/dp_display.c
+++ b/drivers/gpu/drm/msm/dp/dp_display.c
@@ -1441,6 +1441,15 @@ static void msm_dp_display_remove(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 }
 
+static void msm_dp_display_shutdown(struct platform_device *pdev)
+{
+	struct msm_dp_display_private *dp = dev_get_dp_display_private(&pdev->dev);
+
+	disable_irq(dp->irq);
+	synchronize_irq(dp->irq);
+	pm_runtime_disable(&pdev->dev);
+}
+
 static int msm_dp_pm_runtime_suspend(struct device *dev)
 {
 	struct msm_dp_display_private *dp = dev_get_dp_display_private(dev);
@@ -1487,6 +1496,7 @@ static const struct dev_pm_ops msm_dp_pm_ops = {
 static struct platform_driver msm_dp_display_driver = {
 	.probe  = msm_dp_display_probe,
 	.remove = msm_dp_display_remove,
+	.shutdown = msm_dp_display_shutdown,
 	.driver = {
 		.name = "msm-dp-display",
 		.of_match_table = msm_dp_dt_match,


### PR DESCRIPTION
isable HPD IRQ during shutdown to prevent crash

During system shutdown, the DP HPD interrupt can fire after the platform device has started tearing down and IOMMU translation has been disabled.  The IRQ thread (msm_dp_display_irq_thread) processes the HPD event, and proceeds to access hardware registers. Because IOMMU translation is no longer active at that point, the register access causes a translation fault and a NOC decode error on the interconnect.

Fix this by disabling the IRQ at the interrupt controller before calling pm_runtime_disable() in a new .shutdown callback. synchronize_irq() is called between the two to ensure that any currently-executing instance of the IRQ thread has finished before we proceed.

After this sequence the IRQ line is masked, no new HPD events can be delivered, so no hardware access can race with the IOMMU teardown that follows.

CRs-Fixed: 4550131