### PR TITLE
FROMLIST: ASoC: qcom: q6apm-dai: fallback to BUFFER_BYTES_MAX without reserved memory

### DIFF
--- a/sound/soc/qcom/qdsp6/q6apm-dai.c
+++ b/sound/soc/qcom/qdsp6/q6apm-dai.c
@@ -704,7 +704,9 @@ static int q6apm_dai_memory_map(struct snd_soc_component *component,
 	else
 		phys = substream->dma_buffer.addr | (pdata->sid << 32);
 
-	ret = q6apm_map_memory_fixed_region(dev, graph_id, phys, pdata->reserved_buf_size);
+	ret = q6apm_map_memory_fixed_region(dev, graph_id, phys,
+					    pdata->has_reserved_mem ?
+					    pdata->reserved_buf_size : BUFFER_BYTES_MAX);
 	if (ret < 0)
 		dev_err(dev, "Audio Start: Buffer Allocation failed rc = %d\n", ret);
 


### PR DESCRIPTION
Use BUFFER_BYTES_MAX when reserved memory is not configured instead of always using reserved_buf_size, ensuring correct buffer mapping for non-reserved memory platforms.

Link: https://lore.kernel.org/all/20260624123748.502781-1-ajay.nandam@oss.qualcomm.com/
Signed-off-by: Ajay Kumar Nandam <ajay.nandam@oss.qualcomm.com>

CRs-Fixed: 4585950, 4586059
qli-2.0 GA Critical Fix