### PR TITLE
For qli 2 0 fastrpc rmmod deadlock

### DIFF
--- a/drivers/rpmsg/qcom_glink_native.c
+++ b/drivers/rpmsg/qcom_glink_native.c
@@ -1418,9 +1418,6 @@ static void qcom_glink_destroy_ept(struct rpmsg_endpoint *ept)
 	channel->ept.cb = NULL;
 	spin_unlock_irqrestore(&channel->recv_lock, flags);
 
-	/* Decouple the potential rpdev from the channel */
-	qcom_glink_remove_rpmsg_device(glink, channel);
-
 	qcom_glink_send_close_req(glink, channel);
 }
 


### PR DESCRIPTION

Fixes a deadlock hang during `rmmod fastrpc` caused by `qcom_glink_destroy_ept()` attempting to re-acquire the device core's `device_lock` mutex during driver detach, when the driver core already holds the lock.

This series consists of two commits:

### 1. UPSTREAM: rpmsg: glink: remove duplicate code for rpmsg device remove
*(upstream commit `112766cdf2e5`)*

This prerequisite refactoring introduces `qcom_glink_remove_rpmsg_device()` as a shared helper and consolidates rpmsg device teardown logic that was previously duplicated across:

- `qcom_glink_destroy_ept()`
- `qcom_glink_rx_close()`
- `qcom_glink_rx_close_ack()`

The change was merged upstream together with the stable-tagged leak fix (`a53e356df548`, already present in this branch as `f80e4e91b010`), but it never carried a stable/Cc tag itself. As a result, stable auto-backporting did not pick it up, leaving this branch without the required refactoring.

### 2. FROMLIST: rpmsg: glink: fix deadlock in endpoint destroy during driver detach
*([Lore link](https://lore.kernel.org/all/j55nm6bcbwrmynrj3ig7azail5aoxmjaurbzbdcmpink7c6mh6@va26vzo3y7ey/))*

This is the actual fix.

It removes the redundant rpmsg device unregistration from `qcom_glink_destroy_ept()`.

In both paths that lead to endpoint destruction, the rpmsg device has already been unregistered:

- During driver detach, the driver core performs rpmsg device teardown before endpoint destruction.
- During channel close, the rpmsg device has already been removed earlier in the close path.

The additional unregistration attempt in `qcom_glink_destroy_ept()` is therefore unnecessary and becomes the direct cause of the `device_lock` re-entrancy deadlock during driver removal.

## Dependency

Commit 2 depends on Commit 1 because the fix removes a call introduced by the refactoring that centralized rpmsg device teardown into `qcom_rpmsg_device()`.


CRs-Fixed: 4591887
