### PR TITLE
FROMLIST: arm64: dts: qcom: shikra: Add missing CPU OPPs

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -192,33 +192,38 @@
 		compatible = "operating-points-v2";
 		opp-shared;
 
-		cpu0_opp_768mhz: opp-768000000 {
+		opp-768000000 {
 			opp-hz = /bits/ 64 <768000000>;
 			opp-peak-kBps = <1200000 17817600>;
 		};
 
-		cpu0_opp_1017mhz: opp-1017600000 {
+		opp-1017600000 {
 			opp-hz = /bits/ 64 <1017600000>;
 			opp-peak-kBps = <2188000 25804800>;
 		};
 
-		cpu0_opp_1094mhz: opp-1094400000 {
+		opp-1094400000 {
 			opp-hz = /bits/ 64 <1094400000>;
 			opp-peak-kBps = <3072000 30105600>;
 		};
 
-		cpu0_opp_1497mhz: opp-1497600000 {
+		opp-1497600000 {
 			opp-hz = /bits/ 64 <1497600000>;
 			opp-peak-kBps = <4068000 38707200>;
 		};
 
-		cpu0_opp_1612mhz: opp-1612800000 {
+		opp-1612800000 {
 			opp-hz = /bits/ 64 <1612800000>;
 			opp-peak-kBps = <6220000 43008000>;
 		};
 
-		cpu0_opp_1804mhz: opp-1804800000 {
+		opp-1804800000 {
 			opp-hz = /bits/ 64 <1804800000>;
+			opp-peak-kBps = <7216000 43622400>;
+		};
+
+		opp-2208000000 {
+			opp-hz = /bits/ 64 <2208000000>;
 			opp-peak-kBps = <7216000 43622400>;
 		};
 	};
@@ -227,28 +232,38 @@
 		compatible = "operating-points-v2";
 		opp-shared;
 
-		cpu3_opp_1017mhz: opp-1017600000 {
+		opp-768000000 {
+			opp-hz = /bits/ 64 <768000000>;
+			opp-peak-kBps = <1200000 17817600>;
+		};
+
+		opp-1017600000 {
 			opp-hz = /bits/ 64 <1017600000>;
 			opp-peak-kBps = <2188000 25804800>;
 		};
 
-		cpu3_opp_1190mhz: opp-1190400000 {
+		opp-1190400000 {
 			opp-hz = /bits/ 64 <1190400000>;
 			opp-peak-kBps = <3072000 30105600>;
 		};
 
-		cpu3_opp_1497mhz: opp-1497600000 {
+		opp-1497600000 {
 			opp-hz = /bits/ 64 <1497600000>;
 			opp-peak-kBps = <4068000 38707200>;
 		};
 
-		cpu3_opp_1708mhz: opp-1708800000 {
+		opp-1708800000 {
 			opp-hz = /bits/ 64 <1708800000>;
 			opp-peak-kBps = <6220000 43008000>;
 		};
 
-		cpu3_opp_1900mhz: opp-1900800000 {
+		opp-1900800000 {
 			opp-hz = /bits/ 64 <1900800000>;
+			opp-peak-kBps = <7216000 43622400>;
+		};
+
+		opp-2208000000 {
+			opp-hz = /bits/ 64 <2208000000>;
 			opp-peak-kBps = <7216000 43622400>;
 		};
 	};


### PR DESCRIPTION
Add the 2.208 GHz operating point to the CPU0 and CPU3 OPP tables, and add the 768 MHz operating point to the CPU3 table.

This keeps the Shikra CPU OPP tables aligned with the supported frequency set.

Link: https://lore.kernel.org/all/20260702-shikra-dt-m1-v5-4-f911ac92720c@oss.qualcomm.com/

CRs-Fixed: 4593076