### PR TITLE
FROMLIST: wifi: ath12k: fix ML-STA authentication timeout

### DIFF
--- a/drivers/net/wireless/ath/ath12k/wmi.c
+++ b/drivers/net/wireless/ath/ath12k/wmi.c
@@ -1170,7 +1170,9 @@ int ath12k_wmi_vdev_start(struct ath12k *ar, struct wmi_vdev_start_req_arg *arg,
 				   le32_encode_bits(arg->ml.mcast_link,
 						    ATH12K_WMI_FLAG_MLO_MCAST_VDEV) |
 				   le32_encode_bits(arg->ml.link_add,
-						    ATH12K_WMI_FLAG_MLO_LINK_ADD);
+						    ATH12K_WMI_FLAG_MLO_LINK_ADD) |
+				   le32_encode_bits(arg->ml.assoc_link,
+						    ATH12K_WMI_FLAG_MLO_START_AS_ACTIVE);
 
 		ath12k_dbg(ar->ab, ATH12K_DBG_WMI, "vdev %d start ml flags 0x%x\n",
 			   arg->vdev_id, ml_params->flags);

--- a/drivers/net/wireless/ath/ath12k/wmi.h
+++ b/drivers/net/wireless/ath/ath12k/wmi.h
@@ -2930,6 +2930,7 @@ struct wmi_vdev_create_mlo_params {
 #define ATH12K_WMI_FLAG_MLO_EMLSR_SUPPORT		BIT(6)
 #define ATH12K_WMI_FLAG_MLO_FORCED_INACTIVE		BIT(7)
 #define ATH12K_WMI_FLAG_MLO_LINK_ADD			BIT(8)
+#define ATH12K_WMI_FLAG_MLO_START_AS_ACTIVE		BIT(17)
 
 struct wmi_vdev_start_mlo_params {
 	__le32 tlv_header;


### PR DESCRIPTION
Firmware interprets the MLO_LINK_ADD and MLO_START_AS_ACTIVE flags to control the link state during MLO vdev start. MLO_LINK_ADD indicates that a link is being added, while MLO_START_AS_ACTIVE specifies that the link should become active during the start.

When an association link is added without setting MLO_START_AS_ACTIVE, the firmware may transition the link into a suspended state. In this case, authentication frames transmitted by the host can be dropped, leading to repeated authentication retries and eventual timeout, for example:
  wlp1s0: send auth to <AP> (try 1/3)
  wlp1s0: send auth to <AP> (try 2/3)
  wlp1s0: send auth to <AP> (try 3/3)
  wlp1s0: authentication with <AP> timed out

Avoid triggering this behavior by setting the MLO_START_AS_ACTIVE flag when MLO_ASSOC_LINK is set, which tells the firmware that the current vdev must not enter suspend mode

Tested-on: QCC2072 hw1.0 PCI WLAN.COL.1.0.c2-00068-QCACOLSWPL_V1_TO_SILICONZ-1
Tested-on: WCN7850 hw2.0 PCI WLAN.HMT.1.1.c5-00302-QCAHMTSWPL_V1.0_V2.0_SILICONZ-1.115823.3

Fixes: d8e1f4a19310 ("wifi: ath12k: enable QCC2072 support")

Link: https://lore.kernel.org/linux-wireless/20260704073000.3300099-1-miaoqing.pan@oss.qualcomm.com/

CRs-Fixed: 4566992