### PR TITLE
FROMLIST: wifi: ath11k: add purwa-iot-evk and qcs6490-rb3gen2 to usec…

### DIFF
--- a/drivers/net/wireless/ath/ath11k/core.c
+++ b/drivers/net/wireless/ath/ath11k/core.c
@@ -1059,9 +1059,11 @@ static const struct __ath11k_core_usecase_firmware_table {
 	const char *compatible;
 	const char *firmware_name;
 } ath11k_core_usecase_firmware_table[] = {
+	{ ATH11K_HW_WCN6855_HW21, "qcom,hamoa-iot-evk", "nfa765"},
 	{ ATH11K_HW_WCN6855_HW21, "qcom,lemans-evk", "nfa765"},
 	{ ATH11K_HW_WCN6855_HW21, "qcom,monaco-evk", "nfa765"},
-	{ ATH11K_HW_WCN6855_HW21, "qcom,hamoa-iot-evk", "nfa765"},
+	{ ATH11K_HW_WCN6855_HW21, "qcom,purwa-iot-evk", "nfa765"},
+	{ ATH11K_HW_WCN6855_HW21, "qcom,qcs6490-rb3gen2", "nfa765"},
 	{ /* Sentinel */ }
 };
 


### PR DESCRIPTION
…ase firmware table

Add purwa-iot-evk and qcs6490-rb3gen2 platform support to the usecase firmware lookup table for WCN6855 hw2.1.

These platforms use the nfa765 firmware path for usecase-based firmware selection.

Also reorder the table entries by compatible string.

Tested-on: WCN6855 hw2.1 PCI WLAN.HSP.1.1-04685-QCAHSPSWPL_V1_V2_SILICONZ_IOE-1


Link: https://lore.kernel.org/linux-wireless/20260713020359.3618193-1-miaoqing.pan@oss.qualcomm.com/

CRs-Fixed: 4605921