### PR TITLE
Revert "FROMLIST: drm/msm/dp: return 0 from audio_prepare when cable …

### DIFF
--- a/drivers/gpu/drm/msm/dp/dp_audio.c
+++ b/drivers/gpu/drm/msm/dp/dp_audio.c
@@ -284,8 +284,10 @@ int msm_dp_audio_prepare(struct drm_bridge *bridge,
 	 * such cases check for connection status and bail out if not
 	 * connected.
 	 */
-	if (!msm_dp_display->active_stream_cnt)
+	if (!msm_dp_display->active_stream_cnt) {
+		rc = -EINVAL;
 		goto end;
+	}
 
 	audio = msm_dp_audio_get_data(msm_dp_display);
 	if (IS_ERR(audio)) {


### PR DESCRIPTION
…is disconnected"

Commit is NAKed in upstream, so reverting for now.

This reverts commit c3e22773a5465c909550fc64c903bc98a0b6cf9d.