### PR TITLE
shikra: Enable CDSP cooling

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -2765,6 +2765,14 @@
 					};
 				};
 			};
+
+			cooling {
+				compatible = "qcom,qmi-cooling-cdsp";
+					cdsp_sw: cdsp_sw {
+						label = "cdsp_sw";
+						#cooling-cells = <2>;
+					};
+			};
 		};
 
 		remoteproc_lpaicp: remoteproc@b800000 {
@@ -3862,10 +3870,24 @@
 					type = "hot";
 				};
 
-				nsp-critical {
+				nsp_alert1: nsp-alert1 {
 					temperature = <115000>;
+					hysteresis = <5000>;
+					type = "passive";
+				};
+
+				nsp-critical {
+					temperature = <118000>;
 					hysteresis = <0>;
 					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map0 {
+					trip = <&nsp_alert1>;
+					cooling-device = <&cdsp_sw
+							THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
 				};
 			};
 		};


### PR DESCRIPTION
Unlike the CPU, the CDSP does not throttle its speed automatically when it reaches high temperatures in shikra.
Set up CDSP cooling by throttling the cdsp, when it reaches 115°C.

CRs-Fixed: 4617103


