### PR TITLE
FROMLIST: Enable ICE for UFS on Hamoa IoT EVK

### DIFF
--- a/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml
+++ b/Documentation/devicetree/bindings/crypto/qcom,inline-crypto-engine.yaml
@@ -23,6 +23,7 @@ properties:
           - qcom,sm8550-inline-crypto-engine
           - qcom,sm8650-inline-crypto-engine
           - qcom,sm8750-inline-crypto-engine
+          - qcom,x1e80100-inline-crypto-engine
       - const: qcom,inline-crypto-engine
 
   reg:
@@ -55,12 +56,12 @@ additionalProperties: false
 
 allOf:
   - if:
-    properties:
-      compatible:
-        contains:
-          enum:
-            - qcom,eliza-inline-crypto-engine
-            - qcom,milos-inline-crypto-engine
+      properties:
+        compatible:
+          contains:
+            enum:
+              - qcom,eliza-inline-crypto-engine
+              - qcom,milos-inline-crypto-engine
 
     then:
       required:

--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -3932,6 +3932,8 @@
 			phys = <&ufs_mem_phy>;
 			phy-names = "ufsphy";
 
+			qcom,ice = <&ice>;
+
 			#reset-cells = <1>;
 
 			status = "disabled";
@@ -3975,6 +3977,17 @@
 					required-opps = <&rpmhpd_opp_nom>;
 				};
 			};
+		};
+
+		ice: crypto@1d88000 {
+			compatible = "qcom,x1e80100-inline-crypto-engine",
+				     "qcom,inline-crypto-engine";
+			reg = <0x0 0x01d88000 0x0 0x18000>;
+			clocks = <&gcc GCC_UFS_PHY_ICE_CORE_CLK>,
+				 <&gcc GCC_UFS_PHY_AHB_CLK>;
+			clock-names = "core",
+				      "iface";
+			power-domains = <&gcc GCC_UFS_PHY_GDSC>;
 		};
 
 		tcsr_mutex: hwlock@1f40000 {


### PR DESCRIPTION
This series enables the Inline Crypto Engine (ICE) hardware for UFS
storage on the Qualcomm X1E80100 (Hamoa IoT EVK) platform.

The ICE hardware provides AES-256-XTS inline encryption/decryption for
UFS storage, offloading cryptographic operations from the CPU. The
hardware version on this platform is ICE v4.0.1 with HWKM v2 support.

Validation:

Probe successfully
Standard key work well
Patch 1 adds the new compatible string to the DT binding documentation.
Patch 2 adds the ICE device node to the Hamoa DTSI.

Link: https://lore.kernel.org/all/20260722-devtool-v2-0-03f6c82d84fe@oss.qualcomm.com/
Link: https://lore.kernel.org/all/20260722-devtool-v2-1-03f6c82d84fe@oss.qualcomm.com/
Link: https://lore.kernel.org/all/20260722-devtool-v2-2-03f6c82d84fe@oss.qualcomm.com/

Signed-off-by: Wenjia Zhang [wenjz@qti.qualcomm.com](mailto:wenjz@qti.qualcomm.com)
Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>
qcom-next PR: https://github.com/qualcomm-linux/kernel-topics/pull/1547
CRs-Fixed: 4618814