### PR TITLE
FROMLIST: arm64: dts: qcom: lemans: Add PSCI SYSTEM_RESET2 types

### DIFF
--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -797,6 +797,11 @@
 			#power-domain-cells = <0>;
 			domain-idle-states = <&cluster_sleep_apss_rsc_pc>;
 		};
+
+		reboot-mode {
+			mode-bootloader = <0x10001 0x2>;
+			mode-edl = <0 0x1>;
+		};
 	};
 
 	reserved-memory {


### PR DESCRIPTION
Add support for SYSTEM_RESET2 vendor-specific resets as reboot-modes in the psci node.  Describe the resets: "bootloader" will cause device to reboot and stop in the bootloader's fastboot mode.  "edl" will cause device to reboot into "emergency download mode", which permits loading images via the Firehose protocol.

Link: https://lore.kernel.org/r/20251109-arm-psci-system_reset2-vendor-reboots-v17-10-46e085bca4cc@oss.qualcomm.com

CRs-Fixed: 4620493