### PR TITLE
FROMLIST: gpio: Add fwnode_gpiod_get() helper

### DIFF
--- a/include/linux/gpio/consumer.h
+++ b/include/linux/gpio/consumer.h
@@ -586,6 +586,15 @@ static inline int gpiod_disable_hw_timestamp_ns(struct gpio_desc *desc,
 #endif /* CONFIG_GPIOLIB && CONFIG_HTE */
 
 static inline
+struct gpio_desc *fwnode_gpiod_get(struct fwnode_handle *fwnode,
+				   const char *con_id,
+				   enum gpiod_flags flags,
+				   const char *label)
+{
+	return fwnode_gpiod_get_index(fwnode, con_id, 0, flags, label);
+}
+
+static inline
 struct gpio_desc *devm_fwnode_gpiod_get(struct device *dev,
 					struct fwnode_handle *fwnode,
 					const char *con_id,


### PR DESCRIPTION
Add fwnode_gpiod_get() as a convenience wrapper around
fwnode_gpiod_get_index() for the common case where only the
first GPIO is required.

This mirrors existing gpiod_get() and devm_gpiod_get() helpers
and avoids open-coding index 0 at call sites.

Suggested-by: Manivannan Sadhasivam <mani@kernel.org>
Acked-by: Manivannan Sadhasivam <mani@kernel.org>
Reviewed-by: Linus Walleij <linusw@kernel.org>
Acked-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>
Signed-off-by: Krishna Chaitanya Chundru <krishna.chundru@oss.qualcomm.com>
Signed-off-by: Ziyue Zhang <ziyue.zhang@oss.qualcomm.com>

Link: https://lore.kernel.org/all/20260511-wakeirq_support-v10-1-c10af9c9eb8c@oss.qualcomm.com/
CRs-Fixed: 4542930