### PR TITLE
interconnect: core: ignore duplicate bw requests

### DIFF
--- a/drivers/interconnect/core.c
+++ b/drivers/interconnect/core.c
@@ -651,8 +651,10 @@ void icc_set_tag(struct icc_path *path, u32 tag)
 
 	mutex_lock(&icc_lock);
 
-	for (i = 0; i < path->num_nodes; i++)
+	for (i = 0; i < path->num_nodes; i++) {
+		path->reqs[i].prev_tag =  path->reqs[i].tag;
 		path->reqs[i].tag = tag;
+	}
 
 	mutex_unlock(&icc_lock);
 }
@@ -708,6 +710,12 @@ int icc_set_bw(struct icc_path *path, u32 avg_bw, u32 peak_bw)
 
 	old_avg = path->reqs[0].avg_bw;
 	old_peak = path->reqs[0].peak_bw;
+
+	if (path->reqs[0].prev_tag == path->reqs[0].tag &&
+	    (avg_bw == old_avg && peak_bw == old_peak)) {
+		mutex_unlock(&icc_bw_lock);
+		return 0;
+	}
 
 	for (i = 0; i < path->num_nodes; i++) {
 		node = path->reqs[i].node;

--- a/drivers/interconnect/internal.h
+++ b/drivers/interconnect/internal.h
@@ -25,6 +25,7 @@ struct icc_req {
 	struct device *dev;
 	bool enabled;
 	u32 tag;
+	u32 prev_tag;
 	u32 avg_bw;
 	u32 peak_bw;
 };


### PR DESCRIPTION
Ignore the icc_set_bw requests from the client if there is no change with respect to tag, avg_bw and peak_bw values from previous request.