### PR TITLE
media: iris: Fix DMA coherency and frame interval enumeration issues

### DIFF
--- a/Documentation/devicetree/bindings/media/qcom,sc7280-venus.yaml
+++ b/Documentation/devicetree/bindings/media/qcom,sc7280-venus.yaml
@@ -41,6 +41,7 @@ properties:
       - const: iface
       - const: vcodec_core
       - const: vcodec_bus
+  dma-coherent: true
 
   iommus:
     minItems: 1
@@ -86,6 +87,7 @@ properties:
 
 required:
   - compatible
+  - dma-coherent
   - power-domain-names
   - iommus
 
@@ -119,6 +121,7 @@ examples:
         interconnects = <&gem_noc MASTER_APPSS_PROC 0 &cnoc2 SLAVE_VENUS_CFG 0>,
                         <&mmss_noc MASTER_VIDEO_P0 0 &mc_virt SLAVE_EBI1 0>;
         interconnect-names = "cpu-cfg", "video-mem";
+        dma-coherent;
 
         iommus = <&apps_smmu 0x2180 0x20>,
                  <&apps_smmu 0x2184 0x20>;

--- a/arch/arm64/boot/dts/qcom/sc7280.dtsi
+++ b/arch/arm64/boot/dts/qcom/sc7280.dtsi
@@ -4986,6 +4986,7 @@
 			interconnects = <&gem_noc MASTER_APPSS_PROC 0 &cnoc2 SLAVE_VENUS_CFG 0>,
 					<&mmss_noc MASTER_VIDEO_P0 0 &mc_virt SLAVE_EBI1 0>;
 			interconnect-names = "cpu-cfg", "video-mem";
+			dma-coherent;
 
 			iommus = <&apps_smmu 0x2180 0x20>;
 			memory-region = <&video_mem>;

--- a/drivers/media/platform/qcom/iris/iris_vidc.c
+++ b/drivers/media/platform/qcom/iris/iris_vidc.c
@@ -440,14 +440,14 @@ static int iris_enum_frameintervals(struct file *filp, void *fh,
 	mbpf = NUM_MBS_PER_FRAME(fival->height, fival->width);
 	fps = DIV_ROUND_UP(core->iris_platform_data->max_core_mbps, mbpf);
 
-	fival->type = V4L2_FRMIVAL_TYPE_STEPWISE;
+	fival->type = V4L2_FRMIVAL_TYPE_CONTINUOUS;
 	fival->stepwise.min.numerator = 1;
 	fival->stepwise.min.denominator =
 			min_t(u32, fps, MAXIMUM_FPS);
 	fival->stepwise.max.numerator = 1;
 	fival->stepwise.max.denominator = 1;
 	fival->stepwise.step.numerator = 1;
-	fival->stepwise.step.denominator = MAXIMUM_FPS;
+	fival->stepwise.step.denominator = 1;
 
 	return 0;
 }


### PR DESCRIPTION
This series contains two independent fixes for the Qualcomm iris video driver:

- **DMA coherency fix for sc7280 venus node** (`dt-bindings` ): The venus DT node was missing `dma-coherent`, so DMA buffers shared between the CPU and the venus hardware were not guaranteed I/O coherent. This caused hardware faults with high-resolution clips and data corruption in captured output. Adds `dma-coherent` to the binding and to the sc7280 venus node.

- **Frame interval enumeration fix** (`iris_vidc.c`): `iris_enum_frameintervals()` used `V4L2_FRMIVAL_TYPE_STEPWISE` with a fixed step of `1/480`, which only allowed framerates that are exact divisors of 480 fps (480, 240, 120, 60, 30, ...). Non-divisor framerates like 29 or 25 fps were rejected, breaking GStreamer caps negotiation ("internal data stream error"). Switches to `V4L2_FRMIVAL_TYPE_CONTINUOUS` so any integer framerate in `[1, max_fps]` is accepted, as there's no hardware restriction to divisor framerates.

CRs-fixed: 4515234,4446385