### PR TITLE
FROMLIST: ASoC: qcom: sc8280xp: configure codec sysclk for QCS615

### DIFF
--- a/sound/soc/qcom/sc8280xp.c
+++ b/sound/soc/qcom/sc8280xp.c
@@ -382,6 +382,7 @@ static struct snd_soc_common qcs615_priv_data = {
 	.driver_name = "qcs615",
 	.dapm_widgets = sc8280xp_dapm_widgets,
 	.num_dapm_widgets = ARRAY_SIZE(sc8280xp_dapm_widgets),
+	.codec_sysclk_set = true,
 };
 
 static struct snd_soc_common qcm6490_priv_data = {


### PR DESCRIPTION
Continuous high-amplitude noise could occur in the DA7213 microphone capture path after a Bluetooth out-of-range/reset event followed by reconnection. The noise was present in both the raw ALSA capture and PipeWire input, confirming that it originated before Bluetooth encoding.

The codec already obtains and enables MCLK through its DT clock and bias-level handling. However, the machine driver did not explicitly configure the codec sysclk during hw_params(). Enable codec_sysclk_set for QCS615 so that the DA7213 clock source and rate are configured before the codec power-up sequence.

Verified on QCS615 Talos with repeated Bluetooth disconnect and reconnect cycles. The noise was no longer reproducible.

Link: https://lore.kernel.org/all/20260807012450.1038180-1-le.qi@oss.qualcomm.com/

CRs-Fixed: 4612854