### PR TITLE
arm64: dts: qcom: nord: Add UART17 hardware flow-control pins

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -1979,6 +1979,13 @@
 		bias-disable;
 	};
 
+	qup_uart17_cts_rts: qup-uart17-cts-rts-state {
+		pins = "gpio150", "gpio151";
+		function = "qup2_se3";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
 	qup_uart17_default: qup-uart17-default-state {
 		pins = "gpio152", "gpio153";
 		function = "qup2_se3";
@@ -2208,7 +2215,7 @@
 			<&hscnoc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
 			 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>;
 	interconnect-names = "qup-core", "qup-config";
-	pinctrl-0 = <&qup_uart17_default>;
+	pinctrl-0 = <&qup_uart17_default>, <&qup_uart17_cts_rts>;
 	pinctrl-names = "default";
 };
 


### PR DESCRIPTION
Add CTS/RTS pinctrl configuration for UART17 and include it in the default pinctrl state. Configure GPIO150 and GPIO151 for UART17 hardware flow-control operation.