### PR TITLE
Revert "watchdog: fixing incorrect watchdog address and details"

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord.dtsi
@@ -2512,12 +2512,12 @@
 			};
 		};
 
-		watchdog@17821000 {
+		watchdog@17826000 {
 			compatible = "qcom,apss-wdt-nord",
 				     "qcom,kpss-wdt";
-			reg = <0x0 0x17821000 0x0 0x1000>;
+			reg = <0x0 0x17826000 0x0 0x1000>;
 			clocks = <&sleep_clk>;
-			interrupts = <GIC_SPI 0 IRQ_TYPE_EDGE_RISING>;
+			interrupts = <GIC_ESPI 848 IRQ_TYPE_EDGE_RISING>;
 		};
 
 		remoteproc_cdsp0: remoteproc@1f300000 {


### PR DESCRIPTION
This reverts commit c07f7f771a61b31cc4236d311256a512546dba41.

Watchdog WWDOG address was incorrect. 
Changing it correct WDT address fixes kernel panic going to download mode path.

The reverted commit pointed the qcom,kpss-wdt node at WWDOG address.
The corrected address was pointed to NSEC_APSS_WDT address.