### PR TITLE
arm64: dts: qcom: nord: add WCN7850 Bluetooth support

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -69,9 +69,10 @@
 
 	wcn7850-pmu {
 		compatible = "qcom,wcn7850-pmu";
-		pinctrl-0 = <&wcn_wlan_en_state>;
+		pinctrl-0 = <&wcn_bt_en_state>, <&wcn_wlan_en_state>;
 		pinctrl-names = "default";
 
+		bt-enable-gpios = <&kai_mv_e_gpios 9 GPIO_ACTIVE_HIGH>;
 		wlan-enable-gpios = <&kai_mv_e_gpios 10 GPIO_ACTIVE_HIGH>;
 
 		vdd-supply = <&vreg_wcn_3p3>;
@@ -141,6 +142,13 @@
 		gpios = <7 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "wcn-pwr-ctrl";
+	};
+
+	wcn_bt_en_state: wcn-bt-en-state {
+		pins = "gpio9";
+		function = "normal";
+		output-high;
+		bias-pull-down;
 	};
 
 	wcn_wlan_en_state: wcn-wlan-en-state {
@@ -2104,6 +2112,21 @@
 	interconnect-names = "qup-core", "qup-config";
 	pinctrl-0 = <&qup_uart17_default>, <&qup_uart17_cts_rts>;
 	pinctrl-names = "default";
+	status = "okay";
+
+	bluetooth {
+		compatible = "qcom,wcn7850-bt";
+		status = "okay";
+		max-speed = <3200000>;
+
+		vddaon-supply = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
+	};
 };
 
 &uart18 {

--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -1740,6 +1740,13 @@
 		bias-disable;
 	};
 
+	qup_uart17_cts_rts: qup-uart17-cts-rts-state {
+		pins = "gpio150", "gpio151";
+		function = "qup2_se3";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
 	qup_uart18_default: qup-uart18-default-state {
 		pins = "gpio143", "gpio144";
 		function = "qup2_se4";
@@ -1962,7 +1969,7 @@
 			<&hscnoc MASTER_APPSS_PROC QCOM_ICC_TAG_ALWAYS
 			 &config_noc SLAVE_QUP_2 QCOM_ICC_TAG_ALWAYS>;
 	interconnect-names = "qup-core", "qup-config";
-	pinctrl-0 = <&qup_uart17_default>;
+	pinctrl-0 = <&qup_uart17_default>, <&qup_uart17_cts_rts>;
 	pinctrl-names = "default";
 };
 

--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -20,6 +20,7 @@
 #include <dt-bindings/soc/qcom,rpmh-rsc.h>
 
 #include "nord.dtsi"
+#include "kai_mv-nord.dtsi"
 
 / {
 	clk_virt: interconnect-clk-virt {
@@ -32,6 +33,121 @@
 		compatible = "qcom,nord-mc-virt";
 		#interconnect-cells = <2>;
 		qcom,bcm-voters = <&apps_bcm_voter>;
+	};
+
+	vreg_wcn_3p3: regulator-wcn-3p3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_wcn_3p3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	vreg_wcn_core_vl_0p95: regulator-wcn-core-vl-0p95 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_wcn_core_vl_0p95";
+		regulator-min-microvolt = <950000>;
+		regulator-max-microvolt = <950000>;
+		regulator-always-on;
+	};
+
+	vreg_wcn_core_vm_1p35: regulator-wcn-core-vm-1p35 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_wcn_core_vm_1p35";
+		regulator-min-microvolt = <1350000>;
+		regulator-max-microvolt = <1350000>;
+		regulator-always-on;
+	};
+
+	vreg_wcn_core_vh_1p95: regulator-wcn-core-vh-1p95 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_wcn_core_vh_1p95";
+		regulator-min-microvolt = <1950000>;
+		regulator-max-microvolt = <1950000>;
+		regulator-always-on;
+	};
+
+	wcn7850-pmu {
+		compatible = "qcom,wcn7850-pmu";
+		pinctrl-0 = <&wcn_wlan_en_state>;
+		pinctrl-names = "default";
+
+		wlan-enable-gpios = <&kai_mv_e_gpios 10 GPIO_ACTIVE_HIGH>;
+
+		vdd-supply = <&vreg_wcn_3p3>;
+		vddio-supply = <&vreg_s3a_1p8>;
+		vddaon-supply = <&vreg_wcn_core_vl_0p95>;
+		vdddig-supply = <&vreg_wcn_core_vl_0p95>;
+		vddrfa1p2-supply = <&vreg_wcn_core_vm_1p35>;
+		vddrfa1p8-supply = <&vreg_wcn_core_vh_1p95>;
+
+		regulators {
+			vreg_pmu_rfa_cmn: ldo0 {
+				regulator-name = "vreg_pmu_rfa_cmn";
+			};
+
+			vreg_pmu_aon_0p59: ldo1 {
+				regulator-name = "vreg_pmu_aon_0p59";
+			};
+
+			vreg_pmu_wlcx_0p8: ldo2 {
+				regulator-name = "vreg_pmu_wlcx_0p8";
+			};
+
+			vreg_pmu_wlmx_0p85: ldo3 {
+				regulator-name = "vreg_pmu_wlmx_0p85";
+			};
+
+			vreg_pmu_rfa_0p8: ldo5 {
+				regulator-name = "vreg_pmu_rfa_0p8";
+			};
+
+			vreg_pmu_rfa_1p2: ldo6 {
+				regulator-name = "vreg_pmu_rfa_1p2";
+			};
+
+			vreg_pmu_rfa_1p8: ldo7 {
+				regulator-name = "vreg_pmu_rfa_1p8";
+			};
+
+			vreg_pmu_pcie_0p9: ldo8 {
+				regulator-name = "vreg_pmu_pcie_0p9";
+			};
+
+			vreg_pmu_pcie_1p8: ldo9 {
+				regulator-name = "vreg_pmu_pcie_1p8";
+			};
+		};
+	};
+};
+
+&kai_mv_e_gpios {
+	wcn-pwr-core-hog {
+		gpio-hog;
+		gpios = <5 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "wcn-pwr-core";
+	};
+
+	wcn-pwr-ctrl1-hog {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "wcn-pwr-ctrl";
+	};
+
+	wcn-pwr-ctrl2-hog {
+		gpio-hog;
+		gpios = <7 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "wcn-pwr-ctrl";
+	};
+
+	wcn_wlan_en_state: wcn-wlan-en-state {
+		pins = "gpio10";
+		function = "normal";
+		output-low;
+		bias-pull-down;
 	};
 };
 
@@ -1212,6 +1328,23 @@
 		reg = <0x0 0x1fe00000 0x0 0x2a200>;
 		#interconnect-cells = <2>;
 		qcom,bcm-voters = <&apps_bcm_voter>;
+	};
+};
+
+&pcie2_port0 {
+	wifi@0 {
+		compatible = "pci17cb,1107";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
+
+		vddaon-supply = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
+		vddpcie0p9-supply = <&vreg_pmu_pcie_0p9>;
+		vddpcie1p8-supply = <&vreg_pmu_pcie_1p8>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
+++ b/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
@@ -17,6 +17,7 @@
 
 	aliases {
 		serial0 = &uart15;
+		serial1 = &uart17;
 	};
 
 	chosen {

--- a/arch/arm64/boot/dts/qcom/nord-rrd.dts
+++ b/arch/arm64/boot/dts/qcom/nord-rrd.dts
@@ -16,6 +16,7 @@
 
 	aliases {
 		serial0 = &uart15;
+		serial1 = &uart17;
 	};
 
 	chosen {


### PR DESCRIPTION
Add bt-enable-gpios and wcn_bt_en_state pinctrl for gpio9, enable uart17
with a wcn7850-bt child node carrying the required PMU voltage supplies,
and add serial1 alias for uart17 in nord-rrd and nord-ride-sx boards.

Depends-on: https://github.com/qualcomm-linux/kernel/pull/904
Depends-on: https://github.com/qualcomm-linux/kernel/pull/914
Depends-on: https://github.com/qualcomm-linux/kernel/pull/919
Depends-on: https://github.com/qualcomm-linux/kernel/pull/935
