### PR TITLE
Revert "arm64: dts: qcom: nord: Add adreno and PCIe SMMU nodes"

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord.dtsi
@@ -2329,7 +2329,6 @@
 			reg = <0x0 0x03da0000 0x0 0x40000>;
 			#iommu-cells = <2>;
 			#global-interrupts = <1>;
-			dma-coherent;
 			interrupts = <GIC_SPI 673 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 678 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 679 IRQ_TYPE_LEVEL_HIGH>,
@@ -2356,9 +2355,7 @@
 				     <GIC_SPI 669 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 670 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 700 IRQ_TYPE_LEVEL_HIGH>;
-
-			power-domains = <&scmi15_pd 0>;
-			power-domain-names = "power";
+			dma-coherent;
 		};
 
 		adreno_smmu_1: iommu@98a0000 {
@@ -2403,101 +2400,6 @@
 				     <GIC_SPI 900 IRQ_TYPE_EDGE_RISING>,
 				     <GIC_SPI 902 IRQ_TYPE_EDGE_RISING>;
 			interrupt-names = "eventq", "cmdq-sync", "gerror";
-			dma-coherent;
-			#iommu-cells = <1>;
-		};
-
-		adreno_smmu_0: iommu@3da0000 {
-			compatible = "qcom,nord-smmu-500", "qcom,adreno-smmu",
-				     "qcom,smmu-500", "arm,mmu-500";
-			reg = <0x0 0x03da0000 0x0 0x40000>;
-			#iommu-cells = <2>;
-			#global-interrupts = <1>;
-			interrupts = <GIC_SPI 705 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 454 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 478 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 479 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 508 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 606 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 607 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 608 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 609 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 692 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 694 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 697 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 698 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 699 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 701 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 702 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 706 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 707 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 708 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 709 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 710 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 711 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 712 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 713 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 714 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 715 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 716 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 717 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 718 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 719 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 720 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 732 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 733 IRQ_TYPE_LEVEL_HIGH>;
-			dma-coherent;
-		};
-
-		adreno_smmu_1: iommu@98a0000 {
-			compatible = "qcom,nord-smmu-500", "qcom,adreno-smmu",
-				     "qcom,smmu-500", "arm,mmu-500";
-			reg = <0x0 0x098a0000 0x0 0x40000>;
-			#iommu-cells = <2>;
-			#global-interrupts = <1>;
-			interrupts = <GIC_SPI 963 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 883 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 884 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 885 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 886 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 887 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 888 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 889 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 890 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 891 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 892 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 952 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 953 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 954 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 956 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 957 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 958 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 959 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 960 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 961 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 964 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 965 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 966 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 967 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 968 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 969 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 970 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 971 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 972 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 973 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 974 IRQ_TYPE_LEVEL_HIGH>;
-			dma-coherent;
-		};
-
-		pcie_smmu: iommu@9980000 {
-			compatible = "arm,smmu-v3";
-			reg = <0x0 0x09980000 0x0 0x20000>;
-			interrupts = <GIC_SPI 930 IRQ_TYPE_EDGE_RISING>,
-				     <GIC_SPI 932 IRQ_TYPE_EDGE_RISING>,
-				     <GIC_SPI 934 IRQ_TYPE_EDGE_RISING>;
-			interrupt-names = "eventq",
-					  "cmdq-sync",
-					  "gerror";
 			dma-coherent;
 			#iommu-cells = <1>;
 		};


### PR DESCRIPTION
The nord-staging-qcom-next-7.2-rc3-20260807 tag includes the SMMU
nodes from WIP PR #925. PR #930 subsequently landed final SMMU fixes
that include the same nodes, causing duplicate node creation when both
are present. Revert the original addition to resolve the conflict;
the correct SMMU node definitions are now carried by PR #930.

This reverts commit e01e6808687376f7ac3f1043a52a644c00097b43. along with additional fixes related to node arrangement.
