### PR TITLE
lemans: Fix duplicate cdsp_sw cooling device

### DIFF
--- a/Documentation/devicetree/bindings/thermal/qcom,qmi-cooling.yaml
+++ b/Documentation/devicetree/bindings/thermal/qcom,qmi-cooling.yaml
@@ -43,6 +43,7 @@ properties:
     enum:
       - qcom,qmi-cooling-modem
       - qcom,qmi-cooling-cdsp
+      - qcom,qmi-cooling-cdsp1
 
   vdd:
     $ref: "#/definitions/tmd"
@@ -60,7 +61,9 @@ allOf:
       properties:
         compatible:
           contains:
-            const: qcom,qmi-cooling-cdsp
+            enum:
+              - qcom,qmi-cooling-cdsp
+              - qcom,qmi-cooling-cdsp1
     then:
       properties:
         cdsp_sw:

--- a/arch/arm64/boot/dts/qcom/lemans.dtsi
+++ b/arch/arm64/boot/dts/qcom/lemans.dtsi
@@ -7797,7 +7797,7 @@
 
 
 			cooling {
-				compatible = "qcom,qmi-cooling-cdsp";
+				compatible = "qcom,qmi-cooling-cdsp1";
 					cdsp_sw1: cdsp_sw {
 						label = "cdsp_sw";
 						#cooling-cells = <2>;

--- a/drivers/soc/qcom/qmi-cooling.c
+++ b/drivers/soc/qcom/qmi-cooling.c
@@ -26,6 +26,7 @@
 #define MODEM0_INSTANCE_ID	0x0
 #define ADSP_INSTANCE_ID	0x1
 #define CDSP_INSTANCE_ID	0x43
+#define CDSP1_INSTANCE_ID       0x44
 #define SLPI_INSTANCE_ID	0x53
 
 #define QMI_TMD_RESP_TIMEOUT msecs_to_jiffies(100)
@@ -479,6 +480,10 @@ static const struct of_device_id qmi_tmd_device_table[] = {
 	{
 		.compatible = "qcom,qmi-cooling-cdsp",
 		.data = &((struct qmi_instance_data) { CDSP_INSTANCE_ID, "cdsp" }),
+	},
+	{
+	       .compatible = "qcom,qmi-cooling-cdsp1",
+	       .data = &((struct qmi_instance_data) { CDSP1_INSTANCE_ID, "cdsp1" }),
 	},
 	{}
 };


### PR DESCRIPTION
Add a new compatible "qcom,qmi-cooling-cdsp1" with its own instance ID (0x44), and use it for cdsp1's cooling node so each CDSP gets its own distinct cooling device.

CRs-Fixed: 4553608

