### PR TITLE
Nord: PMU | reboot-mode| refresh PAS late-attach

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord.dtsi
@@ -537,6 +537,11 @@
 			#power-domain-cells = <0>;
 			domain-idle-states = <&domain_ss3>;
 		};
+
+		reboot-mode {
+			mode-bootloader = <0x80010001 0x2>;
+			mode-edl = <0x80000000 0x1>;
+		};
 	};
 
 	reserved_memory: reserved-memory {

--- a/arch/arm64/boot/dts/qcom/nord.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord.dtsi
@@ -398,6 +398,11 @@
 		reg = <0x0 0x80000000 0x0 0x0>;
 	};
 
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <GIC_PPI 7 IRQ_TYPE_LEVEL_LOW>;
+	};
+
 	psci {
 		compatible = "arm,psci-1.0";
 		method = "smc";

--- a/drivers/remoteproc/qcom_common.h
+++ b/drivers/remoteproc/qcom_common.h
@@ -68,6 +68,7 @@ struct qcom_sysmon *qcom_add_sysmon_subdev(struct rproc *rproc,
 					   int ssctl_instance);
 void qcom_remove_sysmon_subdev(struct qcom_sysmon *sysmon);
 bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon);
+bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon);
 #else
 static inline struct qcom_sysmon *qcom_add_sysmon_subdev(struct rproc *rproc,
 							 const char *name,
@@ -81,6 +82,11 @@ static inline void qcom_remove_sysmon_subdev(struct qcom_sysmon *sysmon)
 }
 
 static inline bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon)
+{
+	return false;
+}
+
+static inline bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon)
 {
 	return false;
 }

--- a/drivers/remoteproc/qcom_common.h
+++ b/drivers/remoteproc/qcom_common.h
@@ -68,7 +68,6 @@ struct qcom_sysmon *qcom_add_sysmon_subdev(struct rproc *rproc,
 					   int ssctl_instance);
 void qcom_remove_sysmon_subdev(struct qcom_sysmon *sysmon);
 bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon);
-bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon);
 #else
 static inline struct qcom_sysmon *qcom_add_sysmon_subdev(struct rproc *rproc,
 							 const char *name,
@@ -82,11 +81,6 @@ static inline void qcom_remove_sysmon_subdev(struct qcom_sysmon *sysmon)
 }
 
 static inline bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon)
-{
-	return false;
-}
-
-static inline bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon)
 {
 	return false;
 }

--- a/drivers/remoteproc/qcom_q6v5.c
+++ b/drivers/remoteproc/qcom_q6v5.c
@@ -235,7 +235,8 @@ int qcom_q6v5_request_stop(struct qcom_q6v5 *q6v5, struct qcom_sysmon *sysmon)
 	q6v5->running = false;
 
 	/* Don't perform SMP2P dance if remote isn't running */
-	if (q6v5->rproc->state != RPROC_RUNNING || qcom_sysmon_shutdown_acked(sysmon))
+	if ((q6v5->rproc->state != RPROC_RUNNING && q6v5->rproc->state != RPROC_ATTACHED) ||
+	    qcom_sysmon_shutdown_acked(sysmon))
 		return 0;
 
 	qcom_smem_state_update_bits(q6v5->state,

--- a/drivers/remoteproc/qcom_q6v5.c
+++ b/drivers/remoteproc/qcom_q6v5.c
@@ -235,8 +235,7 @@ int qcom_q6v5_request_stop(struct qcom_q6v5 *q6v5, struct qcom_sysmon *sysmon)
 	q6v5->running = false;
 
 	/* Don't perform SMP2P dance if remote isn't running */
-	if ((q6v5->rproc->state != RPROC_RUNNING && q6v5->rproc->state != RPROC_ATTACHED) ||
-	    qcom_sysmon_shutdown_acked(sysmon))
+	if (q6v5->rproc->state != RPROC_RUNNING || qcom_sysmon_shutdown_acked(sysmon))
 		return 0;
 
 	qcom_smem_state_update_bits(q6v5->state,

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -561,17 +561,15 @@ static void qcom_pas_coredump(struct rproc *rproc)
 
 static int qcom_pas_attach(struct rproc *rproc)
 {
+	int ret;
 	struct qcom_pas *pas = rproc->priv;
 	bool ready_state;
 	bool crash_state;
-	bool stop_state;
-	int ret;
-
-	pas->q6v5.handover_issued = true;
 
 	pas->q6v5.running = true;
 	ret = irq_get_irqchip_state(pas->q6v5.fatal_irq,
 				    IRQCHIP_STATE_LINE_LEVEL, &crash_state);
+
 	if (ret)
 		goto disable_running;
 
@@ -582,18 +580,9 @@ static int qcom_pas_attach(struct rproc *rproc)
 		goto disable_running;
 	}
 
-	ret = irq_get_irqchip_state(pas->q6v5.stop_irq,
-				    IRQCHIP_STATE_LINE_LEVEL, &stop_state);
-	if (ret)
-		goto disable_running;
-
-	if (stop_state || qcom_sysmon_shutdown_irq_state(pas->sysmon)) {
-		dev_info(pas->dev, "Subsystem found stop state set. Falling back to start.\n");
-		goto unroll_attach;
-	}
-
 	ret = irq_get_irqchip_state(pas->q6v5.ready_irq,
 				    IRQCHIP_STATE_LINE_LEVEL, &ready_state);
+
 	if (ret)
 		goto disable_running;
 
@@ -604,14 +593,23 @@ static int qcom_pas_attach(struct rproc *rproc)
 		 * start the remoteproc.
 		 */
 		dev_err(pas->dev, "Failed to get subsystem ready interrupt\n");
-		goto unroll_attach;
+		pas->rproc->state = RPROC_OFFLINE;
+		ret = -EINVAL;
+		goto disable_running;
 	}
+
+	ret = qcom_q6v5_ping_subsystem(&pas->q6v5);
+
+	if (ret) {
+		dev_err(pas->dev, "Failed to ping subsystem, assuming device crashed\n");
+		rproc_report_crash(rproc, RPROC_FATAL_ERROR);
+		goto disable_running;
+	}
+
+	pas->q6v5.handover_issued = true;
 
 	return 0;
 
-unroll_attach:
-	pas->rproc->state = RPROC_OFFLINE;
-	ret = -EINVAL;
 disable_running:
 	pas->q6v5.running = false;
 
@@ -639,7 +637,6 @@ static const struct rproc_ops qcom_pas_minidump_ops = {
 	.load = qcom_pas_load,
 	.panic = qcom_pas_panic,
 	.coredump = qcom_pas_minidump,
-	.attach = qcom_pas_attach,
 };
 
 static int qcom_pas_init_clock(struct qcom_pas *pas)
@@ -1022,6 +1019,7 @@ static int qcom_pas_probe(struct platform_device *pdev)
 		else
 			pas->rproc->state = RPROC_DETACHED;
 	}
+
 
 	ret = qcom_pas_setup_tmd(pas);
 	if (ret)

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -561,15 +561,17 @@ static void qcom_pas_coredump(struct rproc *rproc)
 
 static int qcom_pas_attach(struct rproc *rproc)
 {
-	int ret;
 	struct qcom_pas *pas = rproc->priv;
 	bool ready_state;
 	bool crash_state;
+	bool stop_state;
+	int ret;
+
+	pas->q6v5.handover_issued = true;
 
 	pas->q6v5.running = true;
 	ret = irq_get_irqchip_state(pas->q6v5.fatal_irq,
 				    IRQCHIP_STATE_LINE_LEVEL, &crash_state);
-
 	if (ret)
 		goto disable_running;
 
@@ -580,9 +582,18 @@ static int qcom_pas_attach(struct rproc *rproc)
 		goto disable_running;
 	}
 
+	ret = irq_get_irqchip_state(pas->q6v5.stop_irq,
+				    IRQCHIP_STATE_LINE_LEVEL, &stop_state);
+	if (ret)
+		goto disable_running;
+
+	if (stop_state || qcom_sysmon_shutdown_irq_state(pas->sysmon)) {
+		dev_info(pas->dev, "Subsystem found stop state set. Falling back to start.\n");
+		goto unroll_attach;
+	}
+
 	ret = irq_get_irqchip_state(pas->q6v5.ready_irq,
 				    IRQCHIP_STATE_LINE_LEVEL, &ready_state);
-
 	if (ret)
 		goto disable_running;
 
@@ -593,23 +604,14 @@ static int qcom_pas_attach(struct rproc *rproc)
 		 * start the remoteproc.
 		 */
 		dev_err(pas->dev, "Failed to get subsystem ready interrupt\n");
-		pas->rproc->state = RPROC_OFFLINE;
-		ret = -EINVAL;
-		goto disable_running;
+		goto unroll_attach;
 	}
-
-	ret = qcom_q6v5_ping_subsystem(&pas->q6v5);
-
-	if (ret) {
-		dev_err(pas->dev, "Failed to ping subsystem, assuming device crashed\n");
-		rproc_report_crash(rproc, RPROC_FATAL_ERROR);
-		goto disable_running;
-	}
-
-	pas->q6v5.handover_issued = true;
 
 	return 0;
 
+unroll_attach:
+	pas->rproc->state = RPROC_OFFLINE;
+	ret = -EINVAL;
 disable_running:
 	pas->q6v5.running = false;
 
@@ -637,6 +639,7 @@ static const struct rproc_ops qcom_pas_minidump_ops = {
 	.load = qcom_pas_load,
 	.panic = qcom_pas_panic,
 	.coredump = qcom_pas_minidump,
+	.attach = qcom_pas_attach,
 };
 
 static int qcom_pas_init_clock(struct qcom_pas *pas)
@@ -1012,14 +1015,8 @@ static int qcom_pas_probe(struct platform_device *pdev)
 	pas->pas_ctx->use_tzmem = desc->needs_tzmem || rproc->has_iommu;
 	pas->dtb_pas_ctx->use_tzmem = desc->needs_tzmem || rproc->has_iommu;
 
-	if (desc->early_boot) {
-		ret = qcom_q6v5_ping_subsystem_init(&pas->q6v5, pdev);
-		if (ret)
-			dev_warn(&pdev->dev, "Falling back to firmware load\n");
-		else
-			pas->rproc->state = RPROC_DETACHED;
-	}
-
+	if (desc->early_boot)
+		pas->rproc->state = RPROC_DETACHED;
 
 	ret = qcom_pas_setup_tmd(pas);
 	if (ret)

--- a/drivers/remoteproc/qcom_sysmon.c
+++ b/drivers/remoteproc/qcom_sysmon.c
@@ -736,6 +736,25 @@ bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon)
 }
 EXPORT_SYMBOL_GPL(qcom_sysmon_shutdown_acked);
 
+bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon)
+{
+	bool shutdown_state;
+	int ret;
+
+	if (!sysmon)
+		return false;
+
+	ret = irq_get_irqchip_state(sysmon->shutdown_irq,
+				    IRQCHIP_STATE_LINE_LEVEL, &shutdown_state);
+	if (ret) {
+		dev_warn(sysmon->dev, "failed to get shutdown_state: %d\n", ret);
+		return false;
+	}
+
+	return shutdown_state;
+}
+EXPORT_SYMBOL_GPL(qcom_sysmon_shutdown_irq_state);
+
 /**
  * sysmon_probe() - probe sys_mon channel
  * @rpdev:	rpmsg device handle

--- a/drivers/remoteproc/qcom_sysmon.c
+++ b/drivers/remoteproc/qcom_sysmon.c
@@ -736,25 +736,6 @@ bool qcom_sysmon_shutdown_acked(struct qcom_sysmon *sysmon)
 }
 EXPORT_SYMBOL_GPL(qcom_sysmon_shutdown_acked);
 
-bool qcom_sysmon_shutdown_irq_state(struct qcom_sysmon *sysmon)
-{
-	bool shutdown_state;
-	int ret;
-
-	if (!sysmon)
-		return false;
-
-	ret = irq_get_irqchip_state(sysmon->shutdown_irq,
-				    IRQCHIP_STATE_LINE_LEVEL, &shutdown_state);
-	if (ret) {
-		dev_warn(sysmon->dev, "failed to get shutdown_state: %d\n", ret);
-		return false;
-	}
-
-	return shutdown_state;
-}
-EXPORT_SYMBOL_GPL(qcom_sysmon_shutdown_irq_state);
-
 /**
  * sysmon_probe() - probe sys_mon channel
  * @rpdev:	rpmsg device handle


### PR DESCRIPTION
  Four patches on top of origin/staging/nord (9564ae4f19fd):

  - 665a61b2 — PENDING: arm64: dts: qcom: nord: Add PMU node
  - a4728db9 — PENDING: arm64: dts: qcom: nord: Add reboot-mode for EDL and bootloader
  - c38f7cf8 — Revert "FROMGIT: remoteproc: qcom: pas: Add late attach support for subsystems"
  - 0076c721 — FROMGIT: remoteproc: qcom: pas: Add late attach support for subsystems

DT (1–2): add the top-level arm,armv8-pmuv3 node so perf events work on Nord, and a reboot-mode child under psci with the vendor SYSTEM_RESET2 params so userspace can do reboot bootloader / reboot edl.

Remoteproc (3–4): the tree carried an older revision of the late-attach series (74b42530); revert it and re-apply the version picked up upstream (lore link (https://lore.kernel.org/r/20260623-knp-soccp-v7-5-1ec7bb5c9fec@oss.qualcomm.com)). Net delta is confined to qcom_pas_probe() — the probe-time SMP2P ping handshake is dropped, and qcom_pas_attach() now decides purely from the SMP2P IRQ line levels:

  -     if (desc->early_boot) {
  -             ret = qcom_q6v5_ping_subsystem_init(&pas->q6v5, pdev);
  -             ...
  -     }
  +     if (desc->early_boot)
  +             pas->rproc->state = RPROC_DETACHED;

