### PR TITLE
PENDING: arm64: dts: qcom: Enable usb_1/2 controllers on ride platform

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
+++ b/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
@@ -670,10 +670,7 @@
 };
 
 &usb_1 {
-	dr_mode = "host";
-
-	/* Disable to avoid SMMU error */
-	status = "disabled";
+	dr_mode = "peripheral";
 };
 
 &usb_1_hsphy {
@@ -694,9 +691,6 @@
 
 &usb_2 {
 	dr_mode = "host";
-
-	/* Disable to avoid SMMU error */
-	status = "disabled";
 };
 
 &usb_2_hsphy {


### PR DESCRIPTION
The initial crash seen during enablement of usb_1/2 conrtollers were becuase the TZ was giving both the controllers access to GVM. Now that is fixed, enable usb_1 in device mode and usb_2 in host mode.