### PR TITLE
usb: typec: hd3ss3220: Fix VBUS regulator reference handling

### DIFF
--- a/drivers/usb/typec/hd3ss3220.c
+++ b/drivers/usb/typec/hd3ss3220.c
@@ -218,7 +218,7 @@ static void hd3ss3220_regulator_control(struct hd3ss3220 *hd3ss3220, bool on)
 
 	if (ret)
 		dev_err(hd3ss3220->dev,
-			"vbus regulator %s failed: %d\n", on ? "disable" : "enable", ret);
+			"vbus regulator %s failed: %d\n", on ? "enable" : "disable", ret);
 }
 
 static void hd3ss3220_set_role(struct hd3ss3220 *hd3ss3220)

--- a/drivers/usb/typec/hd3ss3220.c
+++ b/drivers/usb/typec/hd3ss3220.c
@@ -62,6 +62,7 @@ struct hd3ss3220 {
 	int id_irq;
 
 	struct regulator *vbus;
+	bool vbus_enabled;
 };
 
 static int hd3ss3220_set_power_opmode(struct hd3ss3220 *hd3ss3220, int power_opmode)
@@ -208,7 +209,7 @@ static void hd3ss3220_regulator_control(struct hd3ss3220 *hd3ss3220, bool on)
 {
 	int ret;
 
-	if (regulator_is_enabled(hd3ss3220->vbus) == on)
+	if (hd3ss3220->vbus_enabled == on)
 		return;
 
 	if (on)
@@ -216,9 +217,13 @@ static void hd3ss3220_regulator_control(struct hd3ss3220 *hd3ss3220, bool on)
 	else
 		ret = regulator_disable(hd3ss3220->vbus);
 
-	if (ret)
+	if (ret) {
 		dev_err(hd3ss3220->dev,
 			"vbus regulator %s failed: %d\n", on ? "enable" : "disable", ret);
+		return;
+	}
+
+	hd3ss3220->vbus_enabled = on;
 }
 
 static void hd3ss3220_set_role(struct hd3ss3220 *hd3ss3220)


### PR DESCRIPTION
The HD3SS3220 driver uses regulator_is_enabled() to determine whether VBUS
needs to be enabled or disabled. However, regulator_is_enabled() reports the
aggregate regulator state and does not indicate whether this consumer holds
an enable reference.

If another consumer enables VBUS first, the driver may skip its own
regulator_enable() call and later issue an unbalanced regulator_disable()
call.

Track the VBUS enable state locally so that regulator enable and disable
references remain balanced for this consumer. Update the state only after a
successful regulator operation.

This PR contains two upstream commits:

1. UPSTREAM: usb: typec: hd3ss3220: fix VBUS regulator error message
   - Upstream commit: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usb.git/commit/?id=10ff55ff552b3bf1dadba03fcc430ea205fa2761
2. UPSTREAM: usb: typec: hd3ss3220: track VBUS enable state per consumer
   - Accepted into the usb-linus branch as:
     https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usb.git/commit/?id=c9a48db776d7184981630ecc01a3ad30a8f7dc24
   - Mailing-list thread:
     https://lore.kernel.org/r/20260819152027.90994-1-kunjinkao.jp@gmail.com

Fixes: 09fa276f21e0 ("FROMLIST: usb: typec: hd3ss3220: Enable VBUS based on role state")

Testing:
- scripts/checkpatch.pl --strict: no errors or warnings
- Qualcomm CI checkpatch, sparse, DT and UAPI checks: passed
- Tested by Jan Remmet on an i.MX95 development board with device/host switching

I am an external contributor and do not have access to Qualcomm's internal
CR system. Maintainer guidance on the appropriate CR association would be
appreciated.

CRs-Fixed: 4676785