### PR TITLE
FROMGIT: thermal: qcom-spmi-adc-tm5: drop IIO_VAL_INT check in adc_tm5_get_temp

### DIFF
--- a/drivers/thermal/qcom/qcom-spmi-adc-tm5.c
+++ b/drivers/thermal/qcom/qcom-spmi-adc-tm5.c
@@ -369,9 +369,6 @@ static int adc_tm5_get_temp(struct thermal_zone_device *tz, int *temp)
 	if (ret < 0)
 		return ret;
 
-	if (ret != IIO_VAL_INT)
-		return -EINVAL;
-
 	return 0;
 }
 


### PR DESCRIPTION
Commit bb21ee31f575 ("iio: Fix iio_multiply_value use in iio_read_channel_processed_scale") fixed the
iio_read_channel_processed_scale to return 0 on success instead of IIO_VAL_INT (1). The existing check in adc_tm5_get_temp() treated a successful return as an error because it expected IIO_VAL_INT. Drop the redundant `ret != IIO_VAL_INT` condition and rely solely on the negative error check

Fixes: bb21ee31f575 ("iio: Fix iio_multiply_value use in iio_read_channel_processed_scale")

Reviewed-by: Jonathan Cameron <jonathan.cameron@oss.qualcomm.com>
Acked-by: Jonathan Cameron <jonathan.cameron@oss.qualcomm.com> #from IIO
Link: https://lore.kernel.org/all/20260724-adc-tm5-drop-iio-val-int-check-v1-1-0b85a0895dd7@oss.qualcomm.com/
CRs-Fixed: 4636200