### PR TITLE
PENDING: pmdomain: qcom: rpmhpd: Add NMXC power domain for Nord SoC

### DIFF
--- a/drivers/pmdomain/qcom/rpmhpd.c
+++ b/drivers/pmdomain/qcom/rpmhpd.c
@@ -232,6 +232,11 @@ static struct rpmhpd qphy = {
 	.res_name = "qphy.lvl",
 };
 
+static struct rpmhpd nmxc = {
+	.pd = { .name = "nmxc", },
+	.res_name = "nmxc.lvl",
+};
+
 static struct rpmhpd gmxc = {
 	.pd = { .name = "gmxc", },
 	.res_name = "gmxc.lvl",
@@ -335,6 +340,7 @@ static struct rpmhpd *nord_rpmhpds[] = {
 	[RPMHPD_NSP1] = &nsp1,
 	[RPMHPD_NSP2] = &nsp2,
 	[RPMHPD_NSP3] = &nsp3,
+	[RPMHPD_NMXC] = &nmxc,
 };
 
 static const struct rpmhpd_desc nord_desc = {

--- a/include/dt-bindings/power/qcom,rpmhpd.h
+++ b/include/dt-bindings/power/qcom,rpmhpd.h
@@ -32,6 +32,7 @@
 #define RPMHPD_GBX		22
 #define RPMHPD_NSP3		23
 #define RPMHPD_GFX1		24
+#define RPMHPD_NMXC		25
 
 /* RPMh Power Domain performance levels */
 #define RPMH_REGULATOR_LEVEL_RETENTION		16


### PR DESCRIPTION
Add the RPMHPD_NMXC generic power domain index and wire up the "nmxc.lvl" ARC resource in the Nord power domain table.  NMXC is a new ARC rail for Nord and is required to control it via the RPMH power domain framework.