### PR TITLE
arm64/qcom: Switch Nord CDSPs from MX to NMXC power domain

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -16,7 +16,7 @@
 #include <dt-bindings/interconnect/qcom,icc.h>
 #include <dt-bindings/interconnect/qcom,nord-rpmh.h>
 #include <dt-bindings/phy/phy-qcom-qmp.h>
-#include <dt-bindings/power/qcom-rpmpd.h>
+#include <dt-bindings/power/qcom,rpmhpd.h>
 #include <dt-bindings/soc/qcom,rpmh-rsc.h>
 
 #include "nord.dtsi"
@@ -605,10 +605,10 @@
 	interconnects = <&nsp_data_noc_0 MASTER_NSP0_PROC QCOM_ICC_TAG_ALWAYS
 			 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 	power-domains = <&rpmhpd RPMHPD_CX>,
-			<&rpmhpd RPMHPD_MX>,
+			<&rpmhpd RPMHPD_NMXC>,
 			<&rpmhpd RPMHPD_NSP0>;
 	power-domain-names = "cx",
-			     "mx",
+			     "nmxc",
 			     "nsp";
 };
 
@@ -618,10 +618,10 @@
 	interconnects = <&nsp_data_noc_1 MASTER_NSP1_PROC QCOM_ICC_TAG_ALWAYS
 			 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 	power-domains = <&rpmhpd RPMHPD_CX>,
-			<&rpmhpd RPMHPD_MX>,
+			<&rpmhpd RPMHPD_NMXC>,
 			<&rpmhpd RPMHPD_NSP1>;
 	power-domain-names = "cx",
-			     "mx",
+			     "nmxc",
 			     "nsp";
 };
 
@@ -631,10 +631,10 @@
 	interconnects = <&nsp_data_noc_2 MASTER_NSP2_PROC QCOM_ICC_TAG_ALWAYS
 			 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 	power-domains = <&rpmhpd RPMHPD_CX>,
-			<&rpmhpd RPMHPD_MX>,
+			<&rpmhpd RPMHPD_NMXC>,
 			<&rpmhpd RPMHPD_NSP2>;
 	power-domain-names = "cx",
-			     "mx",
+			     "nmxc",
 			     "nsp";
 };
 
@@ -644,10 +644,10 @@
 	interconnects = <&nsp_data_noc_3 MASTER_NSP3_PROC QCOM_ICC_TAG_ALWAYS
 			 &mc_virt SLAVE_EBI1 QCOM_ICC_TAG_ALWAYS>;
 	power-domains = <&rpmhpd RPMHPD_CX>,
-			<&rpmhpd RPMHPD_MX>,
+			<&rpmhpd RPMHPD_NMXC>,
 			<&rpmhpd RPMHPD_NSP3>;
 	power-domain-names = "cx",
-			     "mx",
+			     "nmxc",
 			     "nsp";
 };
 

--- a/drivers/pmdomain/qcom/rpmhpd.c
+++ b/drivers/pmdomain/qcom/rpmhpd.c
@@ -202,6 +202,11 @@ static struct rpmhpd mxc_ao = {
 	.skip_retention_level = true,
 };
 
+static struct rpmhpd nmxc = {
+	.pd = { .name = "nmxc", },
+	.res_name = "nmxc.lvl",
+};
+
 static struct rpmhpd nsp = {
 	.pd = { .name = "nsp", },
 	.res_name = "nsp.lvl",
@@ -331,6 +336,7 @@ static struct rpmhpd *nord_rpmhpds[] = {
 	[RPMHPD_MMCX_AO] = &mmcx_ao,
 	[RPMHPD_MXC] = &mxc,
 	[RPMHPD_MXC_AO] = &mxc_ao,
+	[RPMHPD_NMXC] = &nmxc,
 	[RPMHPD_NSP0] = &nsp0,
 	[RPMHPD_NSP1] = &nsp1,
 	[RPMHPD_NSP2] = &nsp2,

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -2084,7 +2084,7 @@ static const struct qcom_pas_data nord_cdsp0_resource = {
 	.auto_boot = true,
 	.proxy_pd_names = (char*[]){
 		"cx",
-		"mx",
+		"nmxc",
 		"nsp",
 		NULL
 	},
@@ -2105,7 +2105,7 @@ static const struct qcom_pas_data nord_cdsp1_resource = {
 	.auto_boot = true,
 	.proxy_pd_names = (char*[]){
 		"cx",
-		"mx",
+		"nmxc",
 		"nsp",
 		NULL
 	},
@@ -2126,7 +2126,7 @@ static const struct qcom_pas_data nord_cdsp2_resource = {
 	.auto_boot = true,
 	.proxy_pd_names = (char*[]){
 		"cx",
-		"mx",
+		"nmxc",
 		"nsp",
 		NULL
 	},
@@ -2147,7 +2147,7 @@ static const struct qcom_pas_data nord_cdsp3_resource = {
 	.auto_boot = true,
 	.proxy_pd_names = (char*[]){
 		"cx",
-		"mx",
+		"nmxc",
 		"nsp",
 		NULL
 	},

--- a/include/dt-bindings/power/qcom,rpmhpd.h
+++ b/include/dt-bindings/power/qcom,rpmhpd.h
@@ -32,6 +32,7 @@
 #define RPMHPD_GBX		22
 #define RPMHPD_NSP3		23
 #define RPMHPD_GFX1		24
+#define RPMHPD_NMXC		25
 
 /* RPMh Power Domain performance levels */
 #define RPMH_REGULATOR_LEVEL_RETENTION		16


### PR DESCRIPTION
The CDSP subsystems on Nord keep their memory rail on a dedicated NMXC resource rather than the shared MX rail used by other subsystems. Keeping the driver's proxy power-domain list and the DT power-domain references in sync with this dedicated rail is required for correct power   sequencing during PAS authentication/boot of the four CDSP remoteprocs.   

 Dependency ordering   

 Binding → pmdomain driver → PAS driver → DT, so that each consumer of RPMHPD_NMXC/"nmxc" builds against a tree where the index/resource already exists.