### PR TITLE
PENDING: arm64: dts: qcom: Enable usb_1/2 controllers on ride-sx

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
+++ b/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
@@ -521,6 +521,10 @@
 	};
 };
 
+&eud_ep {
+	remote-endpoint = <&usb_0_dwc3_hs>;
+};
+
 &i2c9 {
 	clock-frequency = <400000>;
 
@@ -667,6 +671,10 @@
 	status = "okay";
 };
 
+&usb_0_dwc3_hs {
+	remote-endpoint = <&eud_ep>;
+};
+
 &usb_0_hsphy {
 	vdd-supply = <&vreg_l1e_0p9>;
 	vdda12-supply = <&vreg_l2i_1p2>;
@@ -693,7 +701,6 @@
 
 &usb_1 {
 	dr_mode = "peripheral";
-
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/qcom/nord.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord.dtsi
@@ -1761,8 +1761,6 @@
 
 			snps,dis-u1-entry-quirk;
 			snps,dis-u2-entry-quirk;
-
-			status = "disabled";
 		};
 
 		usb_0: usb@a600000 {
@@ -2112,6 +2110,32 @@
 							 <&apps_smmu_0 0x0a76 0x0020>,
 							 <&apps_smmu_0 0x0a96 0x0000>;
 						dma-coherent;
+					};
+				};
+			};
+		};
+
+		eud: eud@88e7000 {
+			compatible = "qcom,sc7280-eud", "qcom,eud";
+			reg = <0x0 0x088e7000 0x0 0x2000>,
+			      <0x0 0x088e9000 0x0 0x1000>;
+			interrupts-extended = <&pdc 11 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+
+					eud_ep: endpoint {
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+
+					eud_con: endpoint {
 					};
 				};
 			};


### PR DESCRIPTION
The initial crash seen during enablement of usb_1/2 conrtollers were becuase the TZ was giving both the controllers access to GVM. Now that is fixed, enable usb_1 in device mode and usb_2 in host mode. Also, enabled eud as well as marked some of the nodes status as okay to enable them.
