### PR TITLE
FROMLIST: arm64: dts: qcom: shikra: Enable dTPM on EVK boards

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqm-evk.dts
@@ -709,6 +709,16 @@
 	};
 };
 
+&spi5 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &uart8 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-cqs-evk.dts
@@ -632,6 +632,16 @@
 	};
 };
 
+&spi5 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &uart8 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -753,6 +753,16 @@
 	};
 };
 
+&spi5 {
+	status = "okay";
+
+	tpm@0 {
+		compatible = "st,st33htpm-spi", "tcg,tpm_tis-spi";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+};
+
 &uart8 {
 	status = "okay";
 


### PR DESCRIPTION
The Shikra EVK boards (CQM, CQS, IQS) carry an ST33 discrete TPM connected via SPI5. Enable the SPI controller and add the TPM node with the ST33HTPM compatible and a 20 MHz max clock.

Depends-on: https://lore.kernel.org/all/20260820085347.822-1-xueyao.an@oss.qualcomm.com/
Link: https://lore.kernel.org/all/20260820-shikra_dtpm-v1-1-40d96b8238bb@oss.qualcomm.com/

qcom-next PR: https://github.com/qualcomm-linux/kernel-topics/pull/1740
Signed-off-by: Khalid Faisal Ansari [khalid.ansari@oss.qualcomm.com](mailto:khalid.ansari@oss.qualcomm.com)

CRs-Fixed: 4654974