### PR TITLE
CMA-memory-to-offload-FNN-PLUS-module-to-eNPU

### DIFF
--- a/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
+++ b/arch/arm64/boot/dts/qcom/kodiak-el2.dtso
@@ -13,7 +13,10 @@
 };
 
 &remoteproc_adsp {
-	iommus = <&apps_smmu 0x1800 0x0>;
+	iommus = <&apps_smmu 0x1800 0x0>,
+		 <&apps_smmu 0x1860 0x9>,
+		 <&apps_smmu 0x1862 0x1>,
+		 <&apps_smmu 0x1864 0x0>;
 };
 
 &remoteproc_cdsp {

--- a/arch/arm64/boot/dts/qcom/qcs6490-audioreach.dtsi
+++ b/arch/arm64/boot/dts/qcom/qcs6490-audioreach.dtsi
@@ -97,6 +97,7 @@
 			q6apmdai: dais {
 				compatible = "qcom,q6apm-dais";
 				iommus = <&apps_smmu 0x1801 0x0>;
+				memory-region = <&audio_cma_mem>;
 			};
 
 			q6apmbedai: bedais {

--- a/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dts
@@ -163,6 +163,14 @@
 			reg = <0x0 0xd0600000 0x0 0x100000>;
 			no-map;
 		};
+
+		audio_cma_mem: qcom,audio-ml {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x0 0x00000000 0x0 0xffffffff>;
+			reusable;
+			alignment = <0x0 0x400000>;
+			size = <0x0 0x1000000>;
+		};
 	};
 
 	gpio-keys {


### PR DESCRIPTION
This series contains patches for allocating CMA memory to offload
FNN PLUS module to eNPU.

Link: https://lore.kernel.org/all/20260825133333.376591-1-karthik.s@oss.qualcomm.com/ 