### PR TITLE
PENDING: arm64: dts: qcom: nord: add WCN7850 Bluetooth support

### DIFF
--- a/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
+++ b/arch/arm64/boot/dts/qcom/nord-embedded.dtsi
@@ -70,9 +70,10 @@
 
 	wcn7850-pmu {
 		compatible = "qcom,wcn7850-pmu";
-		pinctrl-0 = <&wcn_wlan_en_state>;
+		pinctrl-0 = <&wcn_bt_en_state>, <&wcn_wlan_en_state>;
 		pinctrl-names = "default";
 
+		bt-enable-gpios = <&pmau0102_e_gpios 9 GPIO_ACTIVE_HIGH>;
 		wlan-enable-gpios = <&pmau0102_e_gpios 10 GPIO_ACTIVE_HIGH>;
 
 		vdd-supply = <&vreg_wcn_3p3>;
@@ -2842,6 +2843,13 @@
 		line-name = "wcn-pwr-ctrl";
 	};
 
+	wcn_bt_en_state: wcn-bt-en-state {
+		pins = "gpio9";
+		function = "normal";
+		output-high;
+		bias-pull-down;
+	};
+
 	wcn_wlan_en_state: wcn-wlan-en-state {
 		pins = "gpio10";
 		function = "normal";
@@ -3735,6 +3743,20 @@
 	interconnect-names = "qup-core", "qup-config";
 	pinctrl-0 = <&qup_uart17_default>, <&qup_uart17_cts_rts>;
 	pinctrl-names = "default";
+	status = "okay";
+
+	bluetooth {
+		compatible = "qcom,wcn7850-bt";
+		max-speed = <3200000>;
+
+		vddaon-supply = <&vreg_pmu_aon_0p59>;
+		vddwlcx-supply = <&vreg_pmu_wlcx_0p8>;
+		vddwlmx-supply = <&vreg_pmu_wlmx_0p85>;
+		vddrfacmn-supply = <&vreg_pmu_rfa_cmn>;
+		vddrfa0p8-supply = <&vreg_pmu_rfa_0p8>;
+		vddrfa1p2-supply = <&vreg_pmu_rfa_1p2>;
+		vddrfa1p8-supply = <&vreg_pmu_rfa_1p8>;
+	};
 };
 
 &uart18 {

--- a/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
+++ b/arch/arm64/boot/dts/qcom/nord-ride-sx.dts
@@ -17,6 +17,7 @@
 
 	aliases {
 		serial0 = &uart15;
+		serial1 = &uart17;
 	};
 
 	chosen {

--- a/arch/arm64/boot/dts/qcom/nord-rrd.dts
+++ b/arch/arm64/boot/dts/qcom/nord-rrd.dts
@@ -17,6 +17,7 @@
 
 	aliases {
 		serial0 = &uart15;
+		serial1 = &uart17;
 	};
 
 	chosen {


### PR DESCRIPTION
Add wcn7850-bt child node with PMU supplies, bt-enable-gpios and wcn_bt_en_state pinctrl. Add serial1 alias on nord-rrd and nord-ride-sx.