### PR TITLE
FROMLIST: PCI: qcom: Add D3cold support

### DIFF
--- a/drivers/pci/controller/dwc/pcie-qcom.c
+++ b/drivers/pci/controller/dwc/pcie-qcom.c
@@ -2093,6 +2093,14 @@ static int qcom_pcie_resume_noirq(struct device *dev)
 		return 0;
 
 	if (pcie->pci->suspended) {
+		if (pcie->use_pm_opp) {
+			ret = qcom_pcie_set_max_opp(dev);
+			if (ret) {
+				dev_err(dev, "Failed to set max OPP: %d\n", ret);
+				return ret;
+			}
+		}
+
 		ret = icc_enable(pcie->icc_cpu);
 		if (ret) {
 			dev_err(dev, "Failed to enable CPU-PCIe interconnect path: %d\n", ret);


### PR DESCRIPTION
During resume from D3cold, set the PCIe controller to the maximum OPP
before enabling the ICC paths and accessing DBI registers. Without this,
qcom_pcie_icc_opp_update() may access DBI before OPP votes are restored,
triggering NoC errors.

The qli2.0 branch merged the D3cold patch (PR #461) before the
'Set max OPP before DBI access during resume' fix was applied, so the
if (pcie->use_pm_opp) block was missing from the if (pcie->pci->suspended)
branch in qcom_pcie_resume_noirq(). This commit brings qli2.0 in sync
with upstream commit 2cc0e7454c78.

Signed-off-by: Krishna Chaitanya Chundru <krishna.chundru@oss.qualcomm.com>
Signed-off-by: Ziyue Zhang <ziyue.zhang@oss.qualcomm.com>

CRs-Fixed:4569097
Link: https://lore.kernel.org/all/20260429-d3cold-v5-5-89e9735b9df6@oss.qualcomm.com/