### PR TITLE
BACKPORT: arm64: dts: qcom: hamoa-iot-evk: Add SDC2 node for hamoa iot evk board

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
+++ b/arch/arm64/boot/dts/qcom/hamoa-iot-evk.dts
@@ -1097,6 +1097,22 @@
 	status = "okay";
 };
 
+&sdhc_2 {
+	cd-gpios = <&tlmm 71 GPIO_ACTIVE_LOW>;
+
+	vmmc-supply = <&vreg_l9b_2p9>;
+	vqmmc-supply = <&vreg_l6b_1p8>;
+
+	no-sdio;
+	no-mmc;
+
+	pinctrl-0 = <&sdc2_default &sdc2_card_det_n>;
+	pinctrl-1 = <&sdc2_sleep &sdc2_card_det_n>;
+	pinctrl-names = "default", "sleep";
+
+	status = "okay";
+};
+
 &smb2360_0 {
 	status = "okay";
 };
@@ -1299,6 +1315,13 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;
+	};
+
+	sdc2_card_det_n: sd-card-det-n-state {
+		pins = "gpio71";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
 	};
 
 	usb1_pwr_1p15_reg_en: usb1-pwr-1p15-reg-en-state {


### PR DESCRIPTION
Enable SD Card host controller for hamoa iot evk board.

Adds the &sdhc_2 node with vmmc/vqmmc supplies, pinctrl references,
and card-detect GPIO, along with the sdc2_card_det_n pinctrl state
for GPIO71.

BACKPORT of upstream commit c679452028e7 (arm64: dts: qcom: hamoa-iot-evk: Add SDC2 node for hamoa iot evk board)

Link: https://lore.kernel.org/r/20260227040201.3700324-1-sarthak.garg@oss.qualcomm.com
CRs-Fixed: 4666653