### PR TITLE
FROMLIST: arm64: dts: qcom: shikra-iqs-som: fix GPIO138 reservation

### DIFF
--- a/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
+++ b/arch/arm64/boot/dts/qcom/shikra-iqs-evk.dts
@@ -648,7 +648,7 @@
 };
 
 &tlmm {
-	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <138 1>, <155 11>;
+	gpio-reserved-ranges = <6 4>, <14 4>, <30 2>, <115 2>, <49 1>, <155 11>;
 
 	dmic_eldo_en_default: dmic-eldo-default-active-state {
 		pins = "gpio71";


### PR DESCRIPTION
The GPIO mappings on the IQS variant differ from the CQ variants. GPIO138 is connected to the RGMII1_RX_CTL pin rather than the NFC ESE Secure IO pin; the latter is connected to GPIO49. This incorrect reservation causes the probe of the second Ethernet port to fail:

  shikra-tlmm 500000.pinctrl: error -EINVAL: pin-138 (5d20000.ethernet)
  shikra-tlmm 500000.pinctrl: error -EINVAL: could not request pin 138
  (GPIO_138) from group gpio138 on device 500000.pinctrl
  qcom-ethqos 5d20000.ethernet: Error applying setting, reverse things back

Replace gpio138 with gpio49 in the reserved list.

CRs-Fixed: 4598845
QLI-Mainline-PR: https://github.com/qualcomm-linux/kernel-topics/pull/1786
Fixes: 779aead2dace ("arm64: dts: qcom: shikra: Add gpio-reserved-ranges to tlmm")
Link: https://lore.kernel.org/linux-arm-msm/20260908-shikra_ethernet_dts-v1-2-69c0c5c7c124@oss.qualcomm.com/
Signed-off-by: Mohd Ayaan Anwar <mohd.anwar@oss.qualcomm.com>