### PR TITLE
FROMLIST: scsi: ufs: ufs-qcom: Add specified gear support for multi gear scaling

### DIFF
--- a/arch/arm64/boot/dts/qcom/hamoa.dtsi
+++ b/arch/arm64/boot/dts/qcom/hamoa.dtsi
@@ -3961,6 +3961,7 @@
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>;
+					opp-level = <1>; /* HS-G1 */
 					required-opps = <&rpmhpd_opp_low_svs>;
 				};
 
@@ -3973,6 +3974,7 @@
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>;
+					opp-level = <3>; /* HS-G3 */
 					required-opps = <&rpmhpd_opp_svs>;
 				};
 
@@ -3985,6 +3987,7 @@
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>,
 						 /bits/ 64 <0>;
+					opp-level = <5>; /* HS-G5 */
 					required-opps = <&rpmhpd_opp_nom>;
 				};
 			};

--- a/drivers/ufs/host/ufs-qcom.c
+++ b/drivers/ufs/host/ufs-qcom.c
@@ -2182,8 +2182,9 @@ static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
 	bool found = false;
 
 	opp = dev_pm_opp_find_freq_exact_indexed(hba->dev, freq, 0, true);
-	if (IS_ERR(opp)) {
-		dev_err(hba->dev, "Failed to find OPP for exact frequency %lu\n", freq);
+	if (IS_ERR_OR_NULL(opp)) {
+		dev_err(hba->dev, "%s: Failed to find OPP for exact frequency %lu\n",
+			__func__, freq);
 		return 0;
 	}
 
@@ -2211,12 +2212,32 @@ static unsigned long ufs_qcom_opp_freq_to_clk_freq(struct ufs_hba *hba,
 
 static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
 {
-	u32 gear = UFS_HS_DONT_CHANGE;
+	struct dev_pm_opp *opp;
 	unsigned long unipro_freq;
+	u32 gear = UFS_HS_DONT_CHANGE;
 
 	if (!hba->use_pm_opp)
 		return gear;
 
+	opp = dev_pm_opp_find_freq_exact_indexed(hba->dev, freq, 0, true);
+	if (IS_ERR_OR_NULL(opp)) {
+		dev_err(hba->dev, "%s: Failed to find OPP for exact frequency %lu\n",
+			__func__, freq);
+		return gear;
+	}
+
+	/* Get HS gear speed from 'opp-level' */
+	gear = dev_pm_opp_get_level(opp);
+	dev_pm_opp_put(opp);
+
+	/*
+	 * Greater than max gear means that there is no specified gear configured in DT
+	 * or the specified gear is invalid.
+	 */
+	if (gear <= hba->max_pwr_info.info.gear_rx)
+		return gear;
+
+	gear = UFS_HS_DONT_CHANGE;
 	unipro_freq = ufs_qcom_opp_freq_to_clk_freq(hba, freq, "core_clk_unipro");
 	switch (unipro_freq) {
 	case 403000000:
@@ -2237,7 +2258,8 @@ static u32 ufs_qcom_freq_to_gear_speed(struct ufs_hba *hba, unsigned long freq)
 		gear = UFS_HS_G1;
 		break;
 	default:
-		dev_err(hba->dev, "%s: Unsupported clock freq : %lu\n", __func__, freq);
+		dev_err(hba->dev, "%s: Unsupported clock freq [sys_clk: %lu, unipro_clk: %lu]\n",
+			__func__, freq, unipro_freq);
 		return UFS_HS_DONT_CHANGE;
 	}
 


### PR DESCRIPTION
This patch series adds support for configuring UFS gear speeds on a per-OPP frequency basis for Qualcomm UFS host controllers, enabling more flexible multi-gear scaling.

On certain Qualcomm platforms, the UFS clock frequency and gear speed do not have a strict one-to-one mapping. To handle this, the first patch introduces a device tree based configuration mechanism using the "opp-level" property within the OPP table. This allows each supported operating frequency to be explicitly associated with a specific HS gear speed. When this property is absent, the driver gracefully falls back to the existing default frequency-to-gear lookup table.

The second patch applies this configuration to the Hamoa platform, assigning the appropriate HS gear levels (G1, G3, G5) to the corresponding OPP frequency entries in the device tree.

[PATCH v1 1/2] scsi: ufs: ufs-qcom: Add specified gear support for multi gear scaling

The UFS clock frequency and gear speed do not necessarily have a strict one-to-one correspondence on all platforms. Introduce a device tree based configuration interface that allows specifying the HS gear speed for each supported operating frequency via the "opp-level" property in the OPP table. When this property is not configured, the driver falls back to the default frequency-to-gear mapping table.

[PATCH v1 2/2] arm64: dts: qcom: Set specified gear configuration for Hamoa

Assign the appropriate UFS HS gear speed levels to each OPP frequency entry in the device tree, enabling proper per-frequency gear scaling (G1 at 75MHz, G3 at 150MHz, G5 at 300MHz).

Link: https://lore.kernel.org/linux-scsi/20260829074355.946543-1-nitin.rawat@oss.qualcomm.com/T/#t
CRs-Fixed: 4595310