### PR TITLE
QCLINUX: arm64: dts: qcom: Update Purwa camera sensor regulator voltage

### DIFF
--- a/arch/arm64/boot/dts/qcom/purwa-camera-sensor.dtsi
+++ b/arch/arm64/boot/dts/qcom/purwa-camera-sensor.dtsi
@@ -20,7 +20,7 @@
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
 		rgltr-cntrl-support;
 		pwm-switch;
-		rgltr-min-voltage = <1808000 2912000>;
+		rgltr-min-voltage = <1800000 2912000>;
 		rgltr-max-voltage = <1808000 2912000>;
 		rgltr-load-current = <120000 120000>;
 		gpio-no-mux = <0>;
@@ -58,7 +58,7 @@
 		power-domains = <&camcc CAM_CC_TITAN_TOP_GDSC>;
 		rgltr-cntrl-support;
 		pwm-switch;
-		rgltr-min-voltage = <1808000 1808000 1056000 2800000>;
+		rgltr-min-voltage = <1800000 1800000 1056000 2800000>;
 		rgltr-max-voltage = <1808000 1808000 1200000 2800000>;
 		rgltr-load-current = <120000 120000 120000 120000>;
 		gpio-no-mux = <0>;


### PR DESCRIPTION
Update rgltr-min-voltage for cam-sensor1 (og0a1b) and cam-sensor4
(imx688) on the Purwa board from 1808000 to 1800000 to match the
corrected vreg_l4m_1p8 / vreg_l6m_1p8 LDO regulator-min-microvolt
value.

CRs-Fixed: 4665973