### PR TITLE
FROMLIST: Shikra: Support for QCE

### DIFF
--- a/Documentation/devicetree/bindings/crypto/qcom-qce.yaml
+++ b/Documentation/devicetree/bindings/crypto/qcom-qce.yaml
@@ -39,6 +39,7 @@ properties:
               - qcom,msm8996-qce
               - qcom,qcm2290-qce
               - qcom,sdm845-qce
+              - qcom,shikra-qce
               - qcom,sm6115-qce
           - const: qcom,ipq4019-qce
           - const: qcom,qce
@@ -49,7 +50,6 @@ properties:
               - qcom,qcs8300-qce
               - qcom,sa8775p-qce
               - qcom,sc7280-qce
-              - qcom,shikra-qce
               - qcom,sm6350-qce
               - qcom,sm8250-qce
               - qcom,sm8350-qce
@@ -128,6 +128,7 @@ allOf:
           contains:
             enum:
               - qcom,qcm2290-qce
+              - qcom,shikra-qce
               - qcom,sm6115-qce
     then:
       properties:

--- a/arch/arm64/boot/dts/qcom/shikra.dtsi
+++ b/arch/arm64/boot/dts/qcom/shikra.dtsi
@@ -1343,10 +1343,12 @@
 			qcom,controlled-remotely;
 			num-channels = <16>;
 			qcom,num-ees = <4>;
+			clocks = <&rpmcc RPM_SMD_CE1_CLK>;
+			clock-names = "bam_clk";
 		};
 
 		crypto: crypto@1b3a000 {
-			compatible = "qcom,shikra-qce", "qcom,sm8150-qce", "qcom,qce";
+			compatible = "qcom,shikra-qce", "qcom,ipq4019-qce", "qcom,qce";
 			reg = <0x0 0x01b3a000 0x0 0x6000>;
 			dmas = <&cryptobam 4>, <&cryptobam 5>;
 			dma-names = "rx", "tx";
@@ -1357,9 +1359,8 @@
 				 <&apps_smmu 0x96 0x0011>,
 				 <&apps_smmu 0x98 0x0001>,
 				 <&apps_smmu 0x9f 0x0>;
-			interconnects = <&system_noc MASTER_CRYPTO_CORE0 0
-					 &mc_virt SLAVE_EBI_CH0 0>;
-			interconnect-names = "memory";
+			clocks = <&rpmcc RPM_SMD_CE1_CLK>;
+			clock-names = "core";
 		};
 
 		qfprom: efuse@1b44000 {


### PR DESCRIPTION
This patch series enable QCE support on Shikra.
Shikra is derived from agatti target and QCE was using different compatible configuration

Also, one more reason to update QCE is, clk-smd-rpm was doing proxy voting and crypto was consuming it. With proxy vote removal, qce need to vote for it's own clocks explicitly which is already being done for agatti target. Adapt same mechanism to Shikra QCE too.
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/arch/arm64/boot/dts/qcom/agatti.dtsi#n889

The current qce configuration will still work but this one is more appropriately describing the hardware.

CRs-fixed: 4663571
qcom-next PR: https://github.com/qualcomm-linux/kernel-topics/pull/1792
Signed-off-by: Kuldeep Singh [kuldeep.singh@oss.qualcomm.com](mailto:kuldeep.singh@oss.qualcomm.com)
Link: https://lore.kernel.org/linux-arm-msm/20260907-b4-shikra_crypto_changse-v6-0-0676f61894b3@oss.qualcomm.com/
Signed-off-by: Roopak Houji [rhouji@qti.qualcomm.com](mailto:rhouji@qti.qualcomm.com)
Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>