### PR TITLE
devfreq: add compatibility wrapper for moved governor.h

### DIFF
--- a/drivers/devfreq/governor.h
+++ b/drivers/devfreq/governor.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Compatibility wrapper for out-of-tree drivers.
+ *
+ * drivers/devfreq/governor.h was moved to include/linux/devfreq-governor.h
+ * by commit 6df46fd1d1b5 ("FROMGIT: PM / devfreq: Move governor.h to a
+ * public header location"), which was backported into qcom-6.18.y.
+ *
+ * Out-of-tree modules (e.g. kgsl-dlkm) that add the devfreq drivers/
+ * directory to their include path via -I$(KERNEL_SRC)/drivers/devfreq and
+ * use #include "governor.h" will land here and be transparently redirected
+ * to the new public header location.
+ *
+ * New drivers must use #include <linux/devfreq-governor.h> directly.
+ * This shim will be removed once all known consumers are updated.
+ */
+#ifndef __DEVFREQ_GOVERNOR_COMPAT_H
+#define __DEVFREQ_GOVERNOR_COMPAT_H
+
+#include <linux/devfreq-governor.h>
+
+#endif /* __DEVFREQ_GOVERNOR_COMPAT_H */


### PR DESCRIPTION
devfreq: add compatibility wrapper for moved governor.h

## Problem

All Yocto nightly builds against `qcom-6.18.y` tip are failing with:

```
governor_msm_adreno_tz.c:30:10: fatal error: governor.h: No such file or directory
governor_gpubw_mon.c:14:10: fatal error: governor.h: No such file or directory
```

## Root Cause

Commit `6df46fd1d1b5` (`FROMGIT: PM / devfreq: Move governor.h to a public
header location`) was backported into `qcom-6.18.y`, relocating
`drivers/devfreq/governor.h` → `include/linux/devfreq-governor.h`.

Out-of-tree modules such as `kgsl-dlkm` build with:
```makefile
ccflags-y += -I$(KERNEL_SRC)/drivers/devfreq
```
and include the header as:
```c
#include "governor.h"
```

`kgsl-dlkm` v1.0.14 guards the new path behind `KERNEL_VERSION(6, 19, 0)`
(matching the upstream mainline target), so on `qcom-6.18.y` the old path
is taken — but the file is gone.

```
last-good:  11cf26cb7862   (governor.h still at drivers/devfreq/)
breaking:   6df46fd1d1b5   ← governor.h moved (backport into 6.18.y)
tip:        acbf23d72fa0
```

## Fix

Add a compatibility wrapper at `drivers/devfreq/governor.h` that
transparently forwards to `<linux/devfreq-governor.h>`. This is the
standard Linux kernel pattern for header relocations (used widely across
subsystems) and avoids breaking existing out-of-tree consumers while they
migrate.

New drivers must use `#include <linux/devfreq-governor.h>` directly.
This shim can be dropped once all known consumers (kgsl-dlkm etc.) are
updated to use the new path.

## Related

- meta-qcom PR (immediate unblock): https://github.com/qualcomm-linux/meta-qcom/pull/3127
- kgsl-dlkm upstream fix (long-term): update version guard from `KERNEL_VERSION(6, 19, 0)` to `__has_include(<linux/devfreq-governor.h>)`

Fixes: 6df46fd1d1b5 ("FROMGIT: PM / devfreq: Move governor.h to a public header location")
